### PR TITLE
PLANNER-2187 Use java 11 minimum for OptaPlanner 8

### DIFF
--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -13,8 +13,8 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
   </properties>

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -14,8 +14,8 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <docker-plugin.version>0.28.0</docker-plugin.version>
   </properties>

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -13,8 +13,8 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 
https://issues.redhat.com/browse/PLANNER-2187

**referenced Pull Requests**: 
https://github.com/kiegroup/optaplanner/pull/950
https://github.com/kiegroup/optaplanner-website/pull/285

paste the link(s) from GitHub here

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
