### PR TITLE
PLANNER-2171 upgrade to quarkus 1.8.1

### DIFF
--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
-    <version.io.quarkus>1.8.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.8.1.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.8.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.8.1.Final</version.io.quarkus>
 
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.8.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.8.1.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id "io.quarkus" version "1.8.0.Final"
+    id "io.quarkus" version "1.8.1.Final"
     id "java"
 }
 

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
-    <version.io.quarkus>1.8.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.8.1.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>


### PR DESCRIPTION
Relates to https://github.com/kiegroup/optaplanner/pull/952

Known issue:

- The native build still doesn't work, due to the issue in this description:
  https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/rest-data-panache.20native.20builds.3F