### PR TITLE
Workaround for rest-data-panache id accessor failure in native build

### DIFF
--- a/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -76,6 +76,11 @@ public class Lesson {
         return id;
     }
 
+    // Setter is workaround for native build issue https://github.com/quarkusio/quarkus/issues/12458
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getSubject() {
         return subject;
     }

--- a/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Room.java
+++ b/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Room.java
@@ -59,6 +59,11 @@ public class Room {
         return id;
     }
 
+    // Setter is workaround for native build issue https://github.com/quarkusio/quarkus/issues/12458
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getName() {
         return name;
     }

--- a/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Timeslot.java
+++ b/quarkus-school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Timeslot.java
@@ -66,6 +66,11 @@ public class Timeslot {
         return id;
     }
 
+    // Setter is workaround for native build issue https://github.com/quarkusio/quarkus/issues/12458
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public DayOfWeek getDayOfWeek() {
         return dayOfWeek;
     }


### PR DESCRIPTION
Caused by https://github.com/quarkusio/quarkus/issues/12458

This fixes the -Dnative build on master. As for 7.x, that's another story.