### PR TITLE
Update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,22 @@
-**Thank you for submitting this pull request**
+<!--
+Thank you for submitting this pull request.
 
-**JIRA**: _(please edit the JIRA link if it exists)_ 
+Please provide all relevant information as outlined below. Feel free to delete
+a section if that type of information is not available.
+-->
 
-[link](https://www.example.com)
+### JIRA
 
-**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_
+<!-- Add a JIRA ticket link if it exists. -->
+<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->
 
-paste the link(s) from GitHub here
+### Referenced pull requests
 
-**How to retest or run**:
-
-* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**
-
-* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**
-
-* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**
-
-* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**
-
-* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**
-
-i.e for running a full downstream build =  **Jenkins do fdb**
+<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
+changes that span multiple kiegroup repositories and depend on each other. -->
+<!-- Example:
+* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
+* https://github.com/kiegroup/drools/pull/3000
+* https://github.com/kiegroup/optaplanner/pull/899
+* etc.
+-->


### PR DESCRIPTION
Copy PR template from optaplanner with the following changes:

1. Remove the checklist section because the quickstart repo doesn't
   affect OptaPlanner's documentation and upgrade recipe.

2. Remove Jenkins commands because PRs to this repo are not checked by
   Jenkins.