### PR TITLE
Add content list and requirements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,21 @@
 = OptaPlanner Quickstarts
 
+This repository contains a growing collection of OptaPlanner quickstarts. 
+
+* Quarkus
+** <<School timetabling>> for Quarkus
+** <<Facility location problem>>
+** <<Factorio layout>>
+* SpringBoot 
+** <<School timetabling>> for SpringBoot
+* Kotlin
+** <<School timetabling>> for Kotlin
+
+== Java + Optaplanner Version Used
+
+Development branch will use the latest version of Java and Optaplanner.
+For now the quickstarts are tested with Java 15 and Optaplanner 8.
+   
 == Get started
 
 To get started with https://www.optaplanner.org/[OptaPlanner],


### PR DESCRIPTION
Added list of content;
Since quick starts are mostly for developers and operators I suggest to concentrate on the technology rather then on the business problem itself.
Also I feel that it is quite important to underline the requirements needed to launch this demos.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
