### PR TITLE
PLANNER-2243 Release OptaPlanner 8.0.0.Final

### DIFF
--- a/build/quickstarts-distribution/pom.xml
+++ b/build/quickstarts-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.0.0.Final</version>
+    <version>8.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-distribution/pom.xml
+++ b/build/quickstarts-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>8.0.0.Final</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.0.0.Final</version>
+    <version>8.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>8.0.0.Final</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
 
@@ -244,18 +244,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.0.1-SNAPSHOT</version.org.optaplanner>
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
 
@@ -244,4 +244,18 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>8.0.0.Final</version>
     <relativePath/>
   </parent>
   <!-- IMPORTANT: the individual quickstarts have no parent pom. -->
@@ -39,18 +39,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.0.0.Final</version>
+    <version>8.0.1-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <!-- IMPORTANT: the individual quickstarts have no parent pom. -->
@@ -39,4 +39,18 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
@@ -173,18 +173,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.0.1-SNAPSHOT</version.org.optaplanner>
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
@@ -173,4 +173,18 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.0.1-SNAPSHOT</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
@@ -166,4 +166,18 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
@@ -166,18 +166,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -155,18 +155,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.0.1-SNAPSHOT</version.org.optaplanner>
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -155,4 +155,18 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 def quarkusVersion = "1.10.0.Final"
-def optaplannerVersion = "8.0.0.Final"
+def optaplannerVersion = "8.0.1-SNAPSHOT"
 
 group = "org.acme"
 version = "0.1.0-SNAPSHOT"
@@ -12,6 +12,13 @@ version = "0.1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     mavenLocal()
+    // To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots).
+    maven {
+        url "https://repository.jboss.org/nexus/content/groups/public/"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
 }
 
 dependencies {

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 def quarkusVersion = "1.10.0.Final"
-def optaplannerVersion = "8.0.0-SNAPSHOT"
+def optaplannerVersion = "8.0.0.Final"
 
 group = "org.acme"
 version = "0.1.0-SNAPSHOT"
@@ -12,13 +12,6 @@ version = "0.1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     mavenLocal()
-    // To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots).
-    maven {
-        url "https://repository.jboss.org/nexus/content/groups/public/"
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
@@ -185,18 +185,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.0.1-SNAPSHOT</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.10.0.Final</version.io.quarkus>
 
@@ -185,4 +185,18 @@
     </profile>
   </profiles>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "8.0.0-SNAPSHOT"
+def optaplannerVersion = "8.0.0.Final"
 
 group = "com.example"
 version = "0.1.0-SNAPSHOT"
@@ -13,13 +13,6 @@ sourceCompatibility = "11"
 repositories {
     mavenCentral()
     mavenLocal()
-    // To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots).
-    maven {
-        url "https://repository.jboss.org/nexus/content/groups/public/"
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "8.0.0.Final"
+def optaplannerVersion = "8.0.1-SNAPSHOT"
 
 group = "com.example"
 version = "0.1.0-SNAPSHOT"
@@ -13,6 +13,13 @@ sourceCompatibility = "11"
 repositories {
     mavenCentral()
     mavenLocal()
+    // To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots).
+    maven {
+        url "https://repository.jboss.org/nexus/content/groups/public/"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
 }
 
 dependencies {

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
     <version.org.springframework.boot>2.2.6.RELEASE</version.org.springframework.boot>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -135,18 +135,4 @@
     </plugins>
   </build>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -8,7 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.0.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.0.1-SNAPSHOT</version.org.optaplanner>
     <version.org.springframework.boot>2.2.6.RELEASE</version.org.springframework.boot>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -135,4 +135,18 @@
     </plugins>
   </build>
 
+  <repositories>
+    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <!-- Get releases only from Maven Central which is faster. -->
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
We end up with 8.0.1-SNAPSHOT on the 8.0.x branch, this PR follows what the release automation will do.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2243
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
