### PR TITLE
Keep the h2 in-memory database when connection is lost

### DIFF
--- a/kotlin-quarkus-school-timetabling/src/main/resources/application.properties
+++ b/kotlin-quarkus-school-timetabling/src/main/resources/application.properties
@@ -29,7 +29,7 @@ quarkus.optaplanner.solver.termination.spent-limit=30s
 
 # "jdbc:h2:mem" doesn't work in native mode, but native mode uses %prod properties
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:school-timetabling
+quarkus.datasource.jdbc.url=jdbc:h2:mem:school-timetabling;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 ########################

--- a/quarkus-maintenance-scheduling/src/main/resources/application.properties
+++ b/quarkus-maintenance-scheduling/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.optaplanner.solver.termination.spent-limit=30s
 
 # "jdbc:h2:mem" doesn't work in native mode, but native mode uses %prod properties
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:maintenance-scheduling
+quarkus.datasource.jdbc.url=jdbc:h2:mem:maintenance-scheduling;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 ########################

--- a/quarkus-school-timetabling/src/main/resources/application.properties
+++ b/quarkus-school-timetabling/src/main/resources/application.properties
@@ -45,7 +45,7 @@ quarkus.optaplanner.solver.termination.spent-limit=30s
 
 # "jdbc:h2:mem" doesn't work in native mode, but native mode uses %prod properties
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:mem:school-timetabling
+quarkus.datasource.jdbc.url=jdbc:h2:mem:school-timetabling;DB_CLOSE_DELAY=-1
 quarkus.hibernate-orm.database.generation=drop-and-create
 
 ########################


### PR DESCRIPTION
This prevents the h2 db from being closed during a demo after the application is idle for a period of time.