### PR TITLE
Upgrade Quarkus to 1.11.0.Final

### DIFF
--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.2.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.10.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.2.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.10.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
 
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <version.org.optaplanner>8.2.0-SNAPSHOT</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
-    <version.io.quarkus>1.10.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <version.org.optaplanner>8.2.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.10.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "1.10.0.Final"
+    id "io.quarkus" version "1.11.0.Final"
 }
 
-def quarkusVersion = "1.10.0.Final"
+def quarkusVersion = "1.11.0.Final"
 def optaplannerVersion = "8.2.0-SNAPSHOT"
 
 group = "org.acme"

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <version.org.optaplanner>8.2.0-SNAPSHOT</version.org.optaplanner>
     <!-- Always update the version also in the build.gradle. -->
-    <version.io.quarkus>1.10.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
