### PR TITLE
Fix the Gradle build

### DIFF
--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: "org.junit.vintage", module: "junit-vintage-engine"
     }
+    testImplementation("org.optaplanner:optaplanner-test:${optaplannerVersion}")
 }
 
 test {


### PR DESCRIPTION
Fixes the following issue in the Gradle build:
```
Task :compileTestJava FAILED
/home/adupliak/repo/optaplanner-quickstarts/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableConstraintProviderTest.java:27: error: package org.optaplanner.test.api.score.stream does not exist
import org.optaplanner.test.api.score.stream.ConstraintVerifier;
```
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
