### PR TITLE
Remove comments for quarkus version update + branch process details

### DIFF
--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -249,7 +249,6 @@
   </profiles>
 
   <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
     <repository>
       <id>jboss-public-repository-group</id>
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -176,7 +176,6 @@
   </profiles>
 
   <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
     <repository>
       <id>jboss-public-repository-group</id>
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -170,7 +170,6 @@
   </profiles>
 
   <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
     <repository>
       <id>jboss-public-repository-group</id>
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -191,7 +191,6 @@
   </profiles>
 
   <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
     <repository>
       <id>jboss-public-repository-group</id>
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -12,7 +12,6 @@ version = "0.1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     mavenLocal()
-    // To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots).
     maven {
         url "https://repository.jboss.org/nexus/content/groups/public/"
         mavenContent {

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -9,7 +9,6 @@
 
   <properties>
     <version.org.optaplanner>8.2.0-SNAPSHOT</version.org.optaplanner>
-    <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.11.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -190,7 +189,6 @@
   </profiles>
 
   <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
     <repository>
       <id>jboss-public-repository-group</id>
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -13,7 +13,6 @@ sourceCompatibility = "11"
 repositories {
     mavenCentral()
     mavenLocal()
-    // To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots).
     maven {
         url "https://repository.jboss.org/nexus/content/groups/public/"
         mavenContent {

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -124,7 +124,6 @@
   </build>
 
   <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
     <repository>
       <id>jboss-public-repository-group</id>
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>


### PR DESCRIPTION
Quarkus time tabling has gradle and maven builders. Versions in both should by synced only by contributors. Removed the comment

Removed information on removing repo for stable since that is related only to ours internal branch process.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
