### PR TITLE
PLANNER-2254 Fix flaky TimeTableControllerTest

### DIFF
--- a/kotlin-quarkus-school-timetabling/src/test/kotlin/org/acme/kotlin/schooltimetabling/rest/TimeTableResourceTest.kt
+++ b/kotlin-quarkus-school-timetabling/src/test/kotlin/org/acme/kotlin/schooltimetabling/rest/TimeTableResourceTest.kt
@@ -37,12 +37,12 @@ class TimeTableResourceTest {
     fun solveDemoDataUntilFeasible() {
         timeTableResource.solve()
         var timeTable: TimeTable = timeTableResource.getTimeTable()
-        while (timeTable.solverStatus != SolverStatus.NOT_SOLVING) {
+        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L)
             timeTable = timeTableResource.getTimeTable()
-        }
+        } while (timeTable.solverStatus != SolverStatus.NOT_SOLVING)
         Assertions.assertFalse(timeTable.lessonList.isEmpty())
         for (lesson in timeTable.lessonList) {
             Assertions.assertNotNull(lesson.timeslot)

--- a/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
+++ b/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
@@ -40,13 +40,14 @@ public class TimeTableResourceTest {
     @Timeout(600_000)
     public void solveDemoDataUntilFeasible() throws InterruptedException {
         timeTableResource.solve();
-        TimeTable timeTable = timeTableResource.getTimeTable();
-        while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        TimeTable timeTable;
+        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
             timeTable = timeTableResource.getTimeTable();
-        }
+        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING);
+
         assertFalse(timeTable.getLessonList().isEmpty());
         for (Lesson lesson : timeTable.getLessonList()) {
             assertNotNull(lesson.getTimeslot());

--- a/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/rest/TimeTableControllerTest.java
+++ b/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/rest/TimeTableControllerTest.java
@@ -42,13 +42,14 @@ public class TimeTableControllerTest {
     @Timeout(600_000)
     public void solveDemoDataUntilFeasible() throws InterruptedException {
         timeTableController.solve();
-        TimeTable timeTable = timeTableController.getTimeTable();
-        while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        TimeTable timeTable;
+        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
             timeTable = timeTableController.getTimeTable();
-        }
+        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING);
+
         assertFalse(timeTable.getLessonList().isEmpty());
         for (Lesson lesson : timeTable.getLessonList()) {
             assertNotNull(lesson.getTimeslot());


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2254

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
