### PR TITLE
Remove popper dependency

### DIFF
--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -99,12 +99,6 @@
       <version>1.6.0</version>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>popper.js</artifactId>
-      <version>1.16.0</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/quarkus-facility-location/src/main/resources/META-INF/resources/index.html
+++ b/quarkus-facility-location/src/main/resources/META-INF/resources/index.html
@@ -108,7 +108,6 @@
 
 <script src="/webjars/leaflet/leaflet.js"></script>
 <script src="/webjars/jquery/jquery.min.js"></script>
-<script src="/webjars/popper.js/umd/popper.min.js"></script>
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
 <script src="app.js" type="text/javascript"></script>
 </body>


### PR DESCRIPTION
Popper is needed for Bootstrap tooltips:
https://getbootstrap.com/docs/4.5/components/tooltips/
but those were removed in ba35784974ba10e6a4c51a7432ff9d63bdd4167e.

Note that popper will still appear in webjars because it is a dependency
of the bootstrap webjar. We could even exclude it but the goal of this
commit is to clean up the POM and not declare a dependency for something
that is not used.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
