### PR TITLE
[PLANNER-2053] Add mutex job badges and separate jobs by assigned crew + demo data refactor

### DIFF
--- a/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/bootstrap/DemoDataGenerator.java
+++ b/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/bootstrap/DemoDataGenerator.java
@@ -39,13 +39,13 @@ import java.util.List;
 @ApplicationScoped
 public class DemoDataGenerator {
 
-    @ConfigProperty(name = "schedule.demoData", defaultValue = "SMALLEST")
+    @ConfigProperty(name = "schedule.demoData", defaultValue = "SMALL")
     public DemoData demoData;
 
     public enum DemoData {
         NONE,
         SMALL,
-        SMALLEST
+        LARGE
     }
 
     @Inject
@@ -66,100 +66,129 @@ public class DemoDataGenerator {
         }
 
         List<MaintainableUnit> maintainableUnitList = new ArrayList<>();
-        maintainableUnitList.add(new MaintainableUnit("Toyota Corolla 1"));
-        maintainableUnitList.add(new MaintainableUnit("Toyota Corolla 2"));
-        maintainableUnitList.add(new MaintainableUnit("Toyota Corolla 3"));
-        maintainableUnitList.add(new MaintainableUnit("Ford Focus 1"));
-        maintainableUnitList.add(new MaintainableUnit("Ford Focus 2"));
-        maintainableUnitList.add(new MaintainableUnit("Ford Focus 3"));
-        maintainableUnitList.add(new MaintainableUnit("Honda Civic 1"));
-        maintainableUnitList.add(new MaintainableUnit("Honda Civic 2"));
-        maintainableUnitList.add(new MaintainableUnit("Honda Civic 3"));
-        if (demoData == DemoData.SMALL) {
-            maintainableUnitList.add(new MaintainableUnit("Toyota Corolla 4"));
-            maintainableUnitList.add(new MaintainableUnit("Toyota Corolla 5"));
-            maintainableUnitList.add(new MaintainableUnit("Toyota Corolla 6"));
-            maintainableUnitList.add(new MaintainableUnit("Ford Focus 4"));
-            maintainableUnitList.add(new MaintainableUnit("Ford Focus 5"));
-            maintainableUnitList.add(new MaintainableUnit("Ford Focus 6"));
-            maintainableUnitList.add(new MaintainableUnit("Honda Civic 4"));
-            maintainableUnitList.add(new MaintainableUnit("Honda Civic 5"));
-            maintainableUnitList.add(new MaintainableUnit("Honda Civic 6"));
+        maintainableUnitList.add(new MaintainableUnit("ABC-001"));
+        maintainableUnitList.add(new MaintainableUnit("BCD-002"));
+        maintainableUnitList.add(new MaintainableUnit("CDE-003"));
+        maintainableUnitList.add(new MaintainableUnit("DEF-004"));
+        maintainableUnitList.add(new MaintainableUnit("EFG-005"));
+        maintainableUnitList.add(new MaintainableUnit("FGH-006"));
+        maintainableUnitList.add(new MaintainableUnit("GHI-007"));
+        maintainableUnitList.add(new MaintainableUnit("HIJ-008"));
+
+        if (demoData == DemoData.LARGE) {
+            maintainableUnitList.add(new MaintainableUnit("IJK-010"));
+            maintainableUnitList.add(new MaintainableUnit("JKL-011"));
+            maintainableUnitList.add(new MaintainableUnit("KLM-012"));
+            maintainableUnitList.add(new MaintainableUnit("LMN-013"));
+            maintainableUnitList.add(new MaintainableUnit("MNO-014"));
+            maintainableUnitList.add(new MaintainableUnit("NOP-015"));
+            maintainableUnitList.add(new MaintainableUnit("OPQ-016"));
+            maintainableUnitList.add(new MaintainableUnit("PQR-017"));
         }
         maintainableUnitRepository.persist(maintainableUnitList);
 
         List<MaintenanceCrew> maintenanceCrewList = new ArrayList<>();
-        maintenanceCrewList.add(new MaintenanceCrew("Crew 1"));
-        maintenanceCrewList.add(new MaintenanceCrew("Crew 2"));
-        maintenanceCrewList.add(new MaintenanceCrew("Crew 3"));
-        if (demoData == DemoData.SMALL) {
-            maintenanceCrewList.add(new MaintenanceCrew("Crew 4"));
-            maintenanceCrewList.add(new MaintenanceCrew("Crew 5"));
-            maintenanceCrewList.add(new MaintenanceCrew("Crew 6"));
-        }
+        maintenanceCrewList.add(new MaintenanceCrew("Crew Alpha"));
+        maintenanceCrewList.add(new MaintenanceCrew("Crew Beta"));
+
         maintenanceCrewRepository.persist(maintenanceCrewList);
 
         List<TimeGrain> timeGrainList = new ArrayList<>();
-        for (int i = 0; i <= 24; i++) {
+        for (int i = 0; i <= 48; i++) {
             timeGrainList.add(new TimeGrain(i));
         }
-        if (demoData == DemoData.SMALL) {
-            for (int i = 25; i <= 48; i++) {
+        if (demoData == DemoData.LARGE) {
+            for (int i = 49; i <= 96; i++) {
                 timeGrainList.add(new TimeGrain(i));
             }
         }
         timeGrainRepository.persist(timeGrainList);
 
         List<MaintenanceJob> maintenanceJobList = new ArrayList<>();
-        maintenanceJobList.add(new MaintenanceJob("Tire change 1", maintainableUnitList.get(0), 0, 24, 1, true));
-        maintenanceJobList.add(new MaintenanceJob("Tire change 2", maintainableUnitList.get(1), 0, 24, 1, true));
-        maintenanceJobList.add(new MaintenanceJob("Tire change 3", maintainableUnitList.get(2), 0, 24, 1, true));
-        maintenanceJobList.add(new MaintenanceJob("Oil change 1", maintainableUnitList.get(3), 8, 24, 2, true));
-        maintenanceJobList.add(new MaintenanceJob("Oil change 2", maintainableUnitList.get(4), 8, 24, 2, true));
-        maintenanceJobList.add(new MaintenanceJob("Oil change 3", maintainableUnitList.get(5), 8, 24, 2, true));
-        maintenanceJobList.add(new MaintenanceJob("Lights inspection 1", maintainableUnitList.get(6), 0, 24, 4, true));
-        maintenanceJobList.add(new MaintenanceJob("Lights inspection 2", maintainableUnitList.get(7), 0, 24, 4, true));
-        maintenanceJobList.add(new MaintenanceJob("Lights inspection 3", maintainableUnitList.get(8), 0, 24, 4, true));
-        maintenanceJobList.add(new MaintenanceJob("Transmission replacement 1", maintainableUnitList.get(0), 0, 24, 8, true));
-        if (demoData == DemoData.SMALL) {
-            maintenanceJobList.add(new MaintenanceJob("Tire change 4", maintainableUnitList.get(9), 24, 48, 1, true));
-            maintenanceJobList.add(new MaintenanceJob("Tire change 5", maintainableUnitList.get(10), 24, 48, 1, true));
-            maintenanceJobList.add(new MaintenanceJob("Tire change 6", maintainableUnitList.get(11), 24, 48, 1, true));
-            maintenanceJobList.add(new MaintenanceJob("Oil change 4", maintainableUnitList.get(12), 32, 48, 2, true));
-            maintenanceJobList.add(new MaintenanceJob("Oil change 5", maintainableUnitList.get(13), 32, 48, 2, true));
-            maintenanceJobList.add(new MaintenanceJob("Oil change 6", maintainableUnitList.get(14), 32, 48, 2, true));
-            maintenanceJobList.add(new MaintenanceJob("Lights inspection 4", maintainableUnitList.get(15), 24, 48, 4, true));
-            maintenanceJobList.add(new MaintenanceJob("Lights inspection 5", maintainableUnitList.get(16), 24, 48, 4, true));
-            maintenanceJobList.add(new MaintenanceJob("Lights inspection 6", maintainableUnitList.get(17), 24, 48, 4, true));
-            maintenanceJobList.add(new MaintenanceJob("Transmission replacement 2", maintainableUnitList.get(9), 24, 48, 8, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 1", maintainableUnitList.get(0), 0, 8, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 2", maintainableUnitList.get(1), 0, 8, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 3", maintainableUnitList.get(2), 0, 8, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 4", maintainableUnitList.get(3), 0, 8, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 5", maintainableUnitList.get(4), 24, 32, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 6", maintainableUnitList.get(5), 24, 32, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 7", maintainableUnitList.get(6), 24, 32, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Tire change 8", maintainableUnitList.get(7), 24, 32, 1, true));
 
-            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 1", maintainableUnitList.get(0), 0, 48, 1, false));
-            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 2", maintainableUnitList.get(1), 0, 48, 1, false));
-            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 3", maintainableUnitList.get(2), 0, 48, 1, false));
-            maintenanceJobList.add(new MaintenanceJob("Air filter inspection 1", maintainableUnitList.get(3), 8, 48, 2, false));
-            maintenanceJobList.add(new MaintenanceJob("Air filter inspection 2", maintainableUnitList.get(4), 8, 48, 2, false));
-            maintenanceJobList.add(new MaintenanceJob("Air filter inspection 3", maintainableUnitList.get(5), 8, 48, 2, false));
-            maintenanceJobList.add(new MaintenanceJob("Tire pressure check 1", maintainableUnitList.get(6), 0, 48, 4, false));
-            maintenanceJobList.add(new MaintenanceJob("Tire pressure check 2", maintainableUnitList.get(7), 0, 48, 4, false));
-            maintenanceJobList.add(new MaintenanceJob("Tire pressure check 3", maintainableUnitList.get(8), 0, 48, 4, false));
-            maintenanceJobList.add(new MaintenanceJob("Battery inspection 1", maintainableUnitList.get(0), 0, 48, 8, false));
+        maintenanceJobList.add(new MaintenanceJob("Oil change 1", maintainableUnitList.get(0), 0, 8, 2, true));
+        maintenanceJobList.add(new MaintenanceJob("Oil change 2", maintainableUnitList.get(1), 0, 8, 2, true));
+        maintenanceJobList.add(new MaintenanceJob("Oil change 3", maintainableUnitList.get(2), 24, 32, 2, true));
+        maintenanceJobList.add(new MaintenanceJob("Oil change 4", maintainableUnitList.get(3), 24, 32, 2, true));
+
+        maintenanceJobList.add(new MaintenanceJob("Car wash 1", maintainableUnitList.get(4), 0, 8, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Car wash 2", maintainableUnitList.get(5), 0, 8, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Car wash 3", maintainableUnitList.get(6), 24, 32, 1, true));
+        maintenanceJobList.add(new MaintenanceJob("Car wash 4", maintainableUnitList.get(7), 24, 32, 1, true));
+
+        if (demoData == DemoData.LARGE) {
+            maintenanceJobList.add(new MaintenanceJob("Tire change 9", maintainableUnitList.get(8), 48, 56, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 10", maintainableUnitList.get(9), 48, 56, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 11", maintainableUnitList.get(10), 48, 56, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 12", maintainableUnitList.get(11), 48, 56, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 13", maintainableUnitList.get(12), 72, 80, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 14", maintainableUnitList.get(13), 72, 80, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 15", maintainableUnitList.get(14), 72, 80, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Tire change 16", maintainableUnitList.get(15), 72, 80, 1, true));
+
+            maintenanceJobList.add(new MaintenanceJob("Oil change 5", maintainableUnitList.get(8), 48, 56, 2, true));
+            maintenanceJobList.add(new MaintenanceJob("Oil change 6", maintainableUnitList.get(9), 48, 56, 2, true));
+            maintenanceJobList.add(new MaintenanceJob("Oil change 7", maintainableUnitList.get(10), 72, 80, 2, true));
+            maintenanceJobList.add(new MaintenanceJob("Oil change 8", maintainableUnitList.get(11), 72, 80, 2, true));
+
+            maintenanceJobList.add(new MaintenanceJob("Car wash 5", maintainableUnitList.get(12), 48, 56, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Car wash 6", maintainableUnitList.get(13), 48, 56, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Car wash 7", maintainableUnitList.get(14), 72, 80, 1, true));
+            maintenanceJobList.add(new MaintenanceJob("Car wash 8", maintainableUnitList.get(15), 72, 80, 1, true));
+
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 1", maintainableUnitList.get(0), 0, 8, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 2", maintainableUnitList.get(1), 0, 8, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 3", maintainableUnitList.get(2), 24, 32, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 4", maintainableUnitList.get(3), 24, 32, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 5", maintainableUnitList.get(4), 48, 56, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 6", maintainableUnitList.get(5), 48, 56, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 7", maintainableUnitList.get(6), 72, 80, 2, false));
+            maintenanceJobList.add(new MaintenanceJob("Wax vehicle 8", maintainableUnitList.get(7), 72, 80, 2, false));
+
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 1", maintainableUnitList.get(8), 0, 8, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 2", maintainableUnitList.get(9), 0, 8, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 3", maintainableUnitList.get(10), 24, 32, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 4", maintainableUnitList.get(11), 24, 32, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 5", maintainableUnitList.get(12), 48, 56, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 6", maintainableUnitList.get(13), 48, 56, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 7", maintainableUnitList.get(14), 72, 80, 1, false));
+            maintenanceJobList.add(new MaintenanceJob("Battery inspection 8", maintainableUnitList.get(15), 72, 80, 1, false));
         }
         maintenanceJobRepository.persist(maintenanceJobList);
 
         List<MutuallyExclusiveJobs> mutuallyExclusiveJobsList = new ArrayList<>();
-        mutuallyExclusiveJobsList.add(
-                new MutuallyExclusiveJobs(maintenanceJobList.get(0), maintenanceJobList.get(1), maintenanceJobList.get(2)));
-        mutuallyExclusiveJobsList.add(
-                new MutuallyExclusiveJobs(maintenanceJobList.get(3), maintenanceJobList.get(4), maintenanceJobList.get(5)));
-        mutuallyExclusiveJobsList.add(
-                new MutuallyExclusiveJobs(maintenanceJobList.get(6), maintenanceJobList.get(7), maintenanceJobList.get(8)));
         if (demoData == DemoData.SMALL) {
-            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs(maintenanceJobList.get(10), maintenanceJobList.get(11),
-                    maintenanceJobList.get(12)));
-            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs(maintenanceJobList.get(13), maintenanceJobList.get(14),
-                    maintenanceJobList.get(15)));
-            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs(maintenanceJobList.get(16), maintenanceJobList.get(17),
-                    maintenanceJobList.get(18)));
+            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs("Tire change", maintenanceJobList.get(0), 
+            maintenanceJobList.get(1), maintenanceJobList.get(2), maintenanceJobList.get(3), maintenanceJobList.get(4),
+            maintenanceJobList.get(5), maintenanceJobList.get(6), maintenanceJobList.get(7)));
+
+        mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs("Oil change", maintenanceJobList.get(8),
+            maintenanceJobList.get(9), maintenanceJobList.get(10), maintenanceJobList.get(11)));
+
+        mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs("Car wash", maintenanceJobList.get(12),
+            maintenanceJobList.get(13), maintenanceJobList.get(14), maintenanceJobList.get(15)));
+        }
+        else if (demoData == DemoData.LARGE) {
+            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs("Tire change", maintenanceJobList.get(0), 
+                maintenanceJobList.get(1), maintenanceJobList.get(2), maintenanceJobList.get(3), maintenanceJobList.get(4),
+                maintenanceJobList.get(5), maintenanceJobList.get(6), maintenanceJobList.get(7), maintenanceJobList.get(16),
+                maintenanceJobList.get(17), maintenanceJobList.get(18), maintenanceJobList.get(19),
+                maintenanceJobList.get(20), maintenanceJobList.get(21), maintenanceJobList.get(22),
+                maintenanceJobList.get(23)));
+            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs("Oil change", maintenanceJobList.get(8),
+                maintenanceJobList.get(9), maintenanceJobList.get(10), maintenanceJobList.get(11), maintenanceJobList.get(24),
+                maintenanceJobList.get(25), maintenanceJobList.get(26), maintenanceJobList.get(27)));
+            mutuallyExclusiveJobsList.add(new MutuallyExclusiveJobs("Car wash", maintenanceJobList.get(12),
+                maintenanceJobList.get(13), maintenanceJobList.get(14), maintenanceJobList.get(15), maintenanceJobList.get(28),
+                maintenanceJobList.get(29), maintenanceJobList.get(30), maintenanceJobList.get(31)));
         }
         mutuallyExclusiveJobsRepository.persist(mutuallyExclusiveJobsList);
     }

--- a/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/MutuallyExclusiveJobs.java
+++ b/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/MutuallyExclusiveJobs.java
@@ -31,13 +31,16 @@ public class MutuallyExclusiveJobs {
     @GeneratedValue
     private Long id;
 
+    private String exclusiveTag;
+
     @OneToMany(fetch = FetchType.EAGER)
     private List<MaintenanceJob> mutexJobs;
 
     public MutuallyExclusiveJobs() {
     }
 
-    public MutuallyExclusiveJobs(MaintenanceJob... mutexJobs) {
+    public MutuallyExclusiveJobs(String exclusiveTag, MaintenanceJob... mutexJobs) {
+        this.exclusiveTag = exclusiveTag;
         this.mutexJobs = Arrays.asList(mutexJobs);
     }
 
@@ -56,6 +59,7 @@ public class MutuallyExclusiveJobs {
     public String toString() {
         return "MutuallyExclusiveJobs{" +
                 "id=" + id +
+                ", exclusiveTag='" + exclusiveTag + '\'' +
                 ", mutexJobs=" + mutexJobs +
                 '}';
     }
@@ -70,6 +74,14 @@ public class MutuallyExclusiveJobs {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public String getExclusiveTag() {
+        return exclusiveTag;
+    }
+
+    public void setExclusiveTag(String exclusiveTag) {
+        this.exclusiveTag = exclusiveTag;
     }
 
     public List<MaintenanceJob> getMutexJobs() {

--- a/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/MutuallyExclusiveJobs.java
+++ b/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/domain/MutuallyExclusiveJobs.java
@@ -34,14 +34,14 @@ public class MutuallyExclusiveJobs {
     private String exclusiveTag;
 
     @OneToMany(fetch = FetchType.EAGER)
-    private List<MaintenanceJob> mutexJobs;
+    private List<MaintenanceJob> mutuallyExclusiveJobList;
 
     public MutuallyExclusiveJobs() {
     }
 
-    public MutuallyExclusiveJobs(String exclusiveTag, MaintenanceJob... mutexJobs) {
+    public MutuallyExclusiveJobs(String exclusiveTag, MaintenanceJob... mutuallyExclusiveJobs) {
         this.exclusiveTag = exclusiveTag;
-        this.mutexJobs = Arrays.asList(mutexJobs);
+        this.mutuallyExclusiveJobList = Arrays.asList(mutuallyExclusiveJobs);
     }
 
     // ************************************************************************
@@ -49,7 +49,7 @@ public class MutuallyExclusiveJobs {
     // ************************************************************************
 
     public boolean isMutuallyExclusive(MaintenanceJob maintenanceJob, MaintenanceJob otherJob) {
-        if (mutexJobs.contains(maintenanceJob) && mutexJobs.contains(otherJob)) {
+        if (mutuallyExclusiveJobList.contains(maintenanceJob) && mutuallyExclusiveJobList.contains(otherJob)) {
             return true;
         }
         return false;
@@ -60,7 +60,7 @@ public class MutuallyExclusiveJobs {
         return "MutuallyExclusiveJobs{" +
                 "id=" + id +
                 ", exclusiveTag='" + exclusiveTag + '\'' +
-                ", mutexJobs=" + mutexJobs +
+                ", mutuallyExclusiveJobList=" + mutuallyExclusiveJobList +
                 '}';
     }
 
@@ -84,11 +84,11 @@ public class MutuallyExclusiveJobs {
         this.exclusiveTag = exclusiveTag;
     }
 
-    public List<MaintenanceJob> getMutexJobs() {
-        return mutexJobs;
+    public List<MaintenanceJob> getMutuallyExclusiveJobList() {
+        return mutuallyExclusiveJobList;
     }
 
-    public void setMutexJobs(List<MaintenanceJob> mutexJobs) {
-        this.mutexJobs = mutexJobs;
+    public void setMutuallyExclusiveJobList(List<MaintenanceJob> mutuallyExclusiveJobs) {
+        this.mutuallyExclusiveJobList = mutuallyExclusiveJobs;
     }
 }

--- a/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/solver/MaintenanceScheduleConstraintProvider.java
+++ b/quarkus-maintenance-scheduling/src/main/java/org/acme/maintenancescheduling/solver/MaintenanceScheduleConstraintProvider.java
@@ -92,10 +92,10 @@ public class MaintenanceScheduleConstraintProvider implements ConstraintProvider
                         lessThan(MaintenanceJob::getId),
                         filtering((maintenanceJob, otherJob) -> maintenanceJob.calculateOverlap(otherJob) > 0))
                 .join(MutuallyExclusiveJobs.class,
-                        filtering((maintenanceJob, otherJob, mutexJobs) -> mutexJobs.isMutuallyExclusive(maintenanceJob,
-                                otherJob)))
+                        filtering((maintenanceJob, otherJob, mutuallyExclusiveJobs) -> 
+                        mutuallyExclusiveJobs.isMutuallyExclusive(maintenanceJob,otherJob)))
                 .penalizeConfigurable("Mutually exclusive jobs cannot overlap",
-                        (maintenanceJob, otherJob, mutexJobs) -> maintenanceJob.calculateOverlap(otherJob));
+                        (maintenanceJob, otherJob, mutuallyExclusiveJobs) -> maintenanceJob.calculateOverlap(otherJob));
     }
 
     public Constraint oneJobPerUnitPerPeriod(ConstraintFactory constraintFactory) {

--- a/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/app.js
@@ -12,7 +12,7 @@ var crewGroups = new vis.DataSet();
 // Configuration for the Timeline
 var options = {
     // Make jobs editable through UI
-    editable: true,
+    // editable: true,
     // Set time zone to UTC
     moment: function (date) {
         return vis.moment(date).utc();

--- a/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/app.js
@@ -1,12 +1,13 @@
 var autoRefreshCount = 0;
 var autoRefreshIntervalId = null;
 
-// Initial date/time
-var initialTimeString = "2020-01-01T00:00:00Z";
+// Initial date/time (next Monday)
+var initialDateTime = moment().utc().startOf('isoWeek').add(1, 'weeks').set('hour', 9);
 
 // DOM element where the Timeline will be attached
 var container = document.getElementById('visualization');
 var assignedMaintenanceJobs = new vis.DataSet();
+var crewGroups = new vis.DataSet();
 
 // Configuration for the Timeline
 var options = {
@@ -25,7 +26,7 @@ var options = {
 };
 
 // Create timeline displaying maintenance jobs
-var timeline = new vis.Timeline(container, assignedMaintenanceJobs, options);
+var timeline = new vis.Timeline(container, assignedMaintenanceJobs, crewGroups, options);
 
 $(document).ready(function () {
     $.ajaxSetup({
@@ -132,22 +133,52 @@ function refreshSchedule(fitSchedule) {
         const unassignedJobs = $("#unassignedJobs");
         unassignedJobs.children().remove();
 
+        // Add a group for each crew
+        crewGroups.clear();
+        $.each(schedule.assignedCrewList, (index, crew) => {
+            crewGroups.add({
+                id: crew.id,
+                content: crew.crewName
+            });
+        });
+
+        // Label each mutex job with tag
+        const jobToMutexTagMap = {};
+        $.each(schedule.mutuallyExclusiveJobsList, (index, mutuallyExclusiveJobs) => {
+            $.each(mutuallyExclusiveJobs.mutexJobs, (index, job) => {
+                if (jobToMutexTagMap[job.jobName] == null) {
+                    jobToMutexTagMap[job.jobName] = [mutuallyExclusiveJobs.exclusiveTag];
+                }
+                else {
+                    jobToMutexTagMap[job.jobName].push(mutuallyExclusiveJobs.exclusiveTag);
+                }
+            });
+        });
+
         assignedMaintenanceJobs.clear();
         $.each(schedule.maintenanceJobList, (index, job) => {
             if (job.assignedCrew != null && job.startingTimeGrain != null) {
                 assignedMaintenanceJobs.add({
                     id: job.id,
-                    content: "<b>" + job.jobName + "</b><br><i>by " + job.assignedCrew.crewName + "</i><br>" +
+                    group: job.assignedCrew.id,
+                    content: `<b>` + job.jobName + `</b><br><i>by ` + job.assignedCrew.crewName + `</i><br>` +
                         job.maintainableUnit.unitName,
-                    start: moment(initialTimeString).add(job.startingTimeGrain.grainIndex, 'hours'),
-                    end: moment(initialTimeString).add(job.startingTimeGrain.grainIndex + job.durationInGrains, 'hours')
+                    start: moment(initialDateTime).add(job.startingTimeGrain.grainIndex, `hours`),
+                    end: moment(initialDateTime).add(job.startingTimeGrain.grainIndex + job.durationInGrains, `hours`)
                 });
             }
             else {
                 const unassignedJobElement = $(`<div class="card bg-secondary"/>`)
                     .append($(`<div class="card-body p-2"/>`)
-                        .append($(`<b h6 class="card-title mb-1"/>`).text(job.jobName))
-                        .append($(`<p class="card-text"/>`).text(job.maintainableUnit.unitName)));
+                    .append($(`<b h6 class="card-title"/>`).text(job.jobName))
+                    .append($(`<br><span class="badge" style="background-color: white"/>`)
+                        .text(job.maintainableUnit.unitName)));
+                // Append mutex tags on jobs
+                $.each(jobToMutexTagMap[job.jobName], (index, mutexTag) => {
+                    const color = pickColor(mutexTag);
+                    unassignedJobElement.append($(`<span class="badge badge-info m-2" style="background-color: ${color}"/>`)
+                        .text(mutexTag));
+                });
                 unassignedJobs.append(unassignedJobElement);
             }
         });
@@ -156,4 +187,56 @@ function refreshSchedule(fitSchedule) {
             timeline.fit();
         }
     });
+}
+
+// ****************************************************************************
+// TangoColorFactory
+// ****************************************************************************
+
+const SEQUENCE_1 = [0x8AE234, 0xFCE94F, 0x729FCF, 0xE9B96E, 0xAD7FA8];
+const SEQUENCE_2 = [0x73D216, 0xEDD400, 0x3465A4, 0xC17D11, 0x75507B];
+
+var colorMap = new Map;
+var nextColorCount = 0;
+
+function pickColor(object) {
+    let color = colorMap[object];
+    if (color !== undefined) {
+        return color;
+    }
+    color = nextColor();
+    colorMap[object] = color;
+    return color;
+}
+
+function nextColor() {
+    let color;
+    let colorIndex = nextColorCount % SEQUENCE_1.length;
+    let shadeIndex = Math.floor(nextColorCount / SEQUENCE_1.length);
+    if (shadeIndex === 0) {
+        color = SEQUENCE_1[colorIndex];
+    } else if (shadeIndex === 1) {
+        color = SEQUENCE_2[colorIndex];
+    } else {
+        shadeIndex -= 3;
+        let floorColor = SEQUENCE_2[colorIndex];
+        let ceilColor = SEQUENCE_1[colorIndex];
+        let base = Math.floor((shadeIndex / 2) + 1);
+        let divisor = 2;
+        while (base >= divisor) {
+            divisor *= 2;
+        }
+        base = (base * 2) - divisor + 1;
+        let shadePercentage = base / divisor;
+        color = buildPercentageColor(floorColor, ceilColor, shadePercentage);
+    }
+    nextColorCount++;
+    return "#" + color.toString(16);
+}
+
+function buildPercentageColor(floorColor, ceilColor, shadePercentage) {
+    let red = (floorColor & 0xFF0000) + Math.floor(shadePercentage * ((ceilColor & 0xFF0000) - (floorColor & 0xFF0000))) & 0xFF0000;
+    let green = (floorColor & 0x00FF00) + Math.floor(shadePercentage * ((ceilColor & 0x00FF00) - (floorColor & 0x00FF00))) & 0x00FF00;
+    let blue = (floorColor & 0x0000FF) + Math.floor(shadePercentage * ((ceilColor & 0x0000FF) - (floorColor & 0x0000FF))) & 0x0000FF;
+    return red | green | blue;
 }

--- a/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/app.js
+++ b/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/app.js
@@ -142,15 +142,15 @@ function refreshSchedule(fitSchedule) {
             });
         });
 
-        // Label each mutex job with tag
-        const jobToMutexTagMap = {};
+        // Label each mutually exclusive job with tag
+        const jobToMutuallyExclusiveTagMap = {};
         $.each(schedule.mutuallyExclusiveJobsList, (index, mutuallyExclusiveJobs) => {
-            $.each(mutuallyExclusiveJobs.mutexJobs, (index, job) => {
-                if (jobToMutexTagMap[job.jobName] == null) {
-                    jobToMutexTagMap[job.jobName] = [mutuallyExclusiveJobs.exclusiveTag];
+            $.each(mutuallyExclusiveJobs.mutuallyExclusiveJobList, (index, job) => {
+                if (jobToMutuallyExclusiveTagMap[job.jobName] == null) {
+                    jobToMutuallyExclusiveTagMap[job.jobName] = [mutuallyExclusiveJobs.exclusiveTag];
                 }
                 else {
-                    jobToMutexTagMap[job.jobName].push(mutuallyExclusiveJobs.exclusiveTag);
+                    jobToMutuallyExclusiveTagMap[job.jobName].push(mutuallyExclusiveJobs.exclusiveTag);
                 }
             });
         });
@@ -173,11 +173,11 @@ function refreshSchedule(fitSchedule) {
                     .append($(`<b h6 class="card-title"/>`).text(job.jobName))
                     .append($(`<br><span class="badge" style="background-color: white"/>`)
                         .text(job.maintainableUnit.unitName)));
-                // Append mutex tags on jobs
-                $.each(jobToMutexTagMap[job.jobName], (index, mutexTag) => {
-                    const color = pickColor(mutexTag);
+                // Append mutually exclusive tags on jobs
+                $.each(jobToMutuallyExclusiveTagMap[job.jobName], (index, mutuallyExclusiveTag) => {
+                    const color = pickColor(mutuallyExclusiveTag);
                     unassignedJobElement.append($(`<span class="badge badge-info m-2" style="background-color: ${color}"/>`)
-                        .text(mutexTag));
+                        .text(mutuallyExclusiveTag));
                 });
                 unassignedJobs.append(unassignedJobElement);
             }

--- a/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/index.html
+++ b/quarkus-maintenance-scheduling/src/main/resources/META-INF/resources/index.html
@@ -54,7 +54,8 @@
         </button>
         <span id="score" class="score ml-2 align-middle font-weight-bold">Score: ?</span>
 
-        <div class="float-right">
+        <!-- TODO: Add job/unit/crew button functionality -->
+        <!-- <div class="float-right">
             <button id="addJobButton" type="button" class="btn btn-primary" data-toggle="modal"
                     data-target="#jobDialog">
                 <span class="fas fa-plus"></span> Add job
@@ -65,7 +66,7 @@
             <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#crewDialog">
                 <span class="fas fa-plus"></span> Add crew
             </button>
-        </div>
+        </div> -->
     </div>
 
     <div id="visualization"></div>

--- a/quarkus-maintenance-scheduling/src/main/resources/application.properties
+++ b/quarkus-maintenance-scheduling/src/main/resources/application.properties
@@ -18,7 +18,7 @@
 # Demo properties
 ########################
 
-# The demo dataset size: NONE, SMALL, SMALLEST
+# The demo dataset size: NONE, SMALL, LARGE
 # schedule.demoData=SMALL
 
 ########################

--- a/quarkus-maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/rest/MutuallyExclusiveJobsResourceTest.java
+++ b/quarkus-maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/rest/MutuallyExclusiveJobsResourceTest.java
@@ -39,7 +39,7 @@ public class MutuallyExclusiveJobsResourceTest {
                 .extract().body().jsonPath().getList(".", MutuallyExclusiveJobs.class);
         assertFalse(mutuallyExclusiveJobsList.isEmpty());
         MutuallyExclusiveJobs firstMutuallyExclusiveJobs = mutuallyExclusiveJobsList.get(0);
-        assertNotNull(firstMutuallyExclusiveJobs.getMutexJobs());
+        assertNotNull(firstMutuallyExclusiveJobs.getMutuallyExclusiveJobList());
     }
 
     @Test

--- a/quarkus-maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/solver/MaintenanceSchedulingConstraintProviderTest.java
+++ b/quarkus-maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/solver/MaintenanceSchedulingConstraintProviderTest.java
@@ -180,7 +180,7 @@ public class MaintenanceSchedulingConstraintProviderTest {
         otherJob.setId(1L);
 
         MutuallyExclusiveJobs mutuallyExclusiveJobs =
-                new MutuallyExclusiveJobs(maintenanceJob, otherJob);
+                new MutuallyExclusiveJobs("Exclusive tag", maintenanceJob, otherJob);
 
         constraintVerifier.verifyThat(MaintenanceScheduleConstraintProvider::mutuallyExclusiveJobs)
                 .given(maintenanceJob, otherJob, mutuallyExclusiveJobs)


### PR DESCRIPTION
Completes first iteration of the Maintenance Scheduling Quarkus Quickstart
Jira: https://issues.redhat.com/browse/PLANNER-2053

- Adds color-coded mutually exclusive job badges
- Separate assigned jobs by their assigned crew in the schedule
- Refactor demo data to better fit the rental car example