### PR TITLE
Fix native build of showcase

### DIFF
--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -137,7 +137,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -8,14 +8,15 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <version.io.quarkus>1.11.0.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
+    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -160,11 +161,11 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -223,7 +224,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -8,10 +8,8 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <version.io.quarkus>1.11.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -8,15 +8,16 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
-
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire-plugin.version>2.22.1</surefire-plugin.version>
+
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
+
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.1</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -123,11 +124,11 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -150,7 +151,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -8,14 +8,15 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -108,7 +109,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
@@ -124,7 +125,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -146,7 +147,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -8,13 +8,14 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
-
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
+
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -127,7 +128,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
@@ -143,7 +144,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -165,7 +166,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -8,13 +8,14 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
-
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
+
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -125,7 +126,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
@@ -141,7 +142,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -163,7 +164,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -8,13 +8,14 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
-
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
+
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -114,7 +115,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
@@ -130,7 +131,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -152,7 +153,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -8,14 +8,15 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>
     <version.org.springframework.boot>2.2.6.RELEASE</version.org.springframework.boot>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -109,7 +110,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler-plugin.version}</version>
+        <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
@@ -118,7 +119,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.surefire.plugin}</version>
       </plugin>
     </plugins>
   </build>

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -8,8 +8,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.org.optaplanner>8.3.0-SNAPSHOT</version.org.optaplanner>


### PR DESCRIPTION
The `surefire-plugin.version` was not defined for the showcase module. The `optaplanner-parent` defines `version.surefire.plugin` instead. This PR unifies the naming of plugin version properties to `version.{plugin name}.plugin`, which we already use in the `optaplanner` repository.

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
