### PR TITLE
Upgrade quarkus to 1.12.0.Final

### DIFF
--- a/build/quickstarts-distribution/src/main/assembly/assembly-optaplanner-quickstarts.xml
+++ b/build/quickstarts-distribution/src/main/assembly/assembly-optaplanner-quickstarts.xml
@@ -69,6 +69,22 @@
         <include>*-runner.jar</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>../../quarkus-maintenance-scheduling/target</directory>
+      <outputDirectory>binaries/quarkus-maintenance-scheduling</outputDirectory>
+      <includes>
+        <include>lib/**</include>
+        <include>*-runner.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>../../quarkus-vaccination-scheduling/target</directory>
+      <outputDirectory>binaries/quarkus-vaccination-scheduling</outputDirectory>
+      <includes>
+        <include>lib/**</include>
+        <include>*-runner.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
 </assembly>

--- a/build/quickstarts-showcase/src/main/resources/application.properties
+++ b/build/quickstarts-showcase/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.12.0.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
     <version.org.optaplanner>8.4.0-SNAPSHOT</version.org.optaplanner>
 

--- a/kotlin-quarkus-school-timetabling/src/main/resources/application.properties
+++ b/kotlin-quarkus-school-timetabling/src/main/resources/application.properties
@@ -48,3 +48,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
+
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <releases>
         <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.12.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.4.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-facility-location/src/main/resources/application.properties
+++ b/quarkus-facility-location/src/main/resources/application.properties
@@ -39,3 +39,6 @@ quarkus.optaplanner.solver.termination.spent-limit=30s
 # Effectively disable this termination in favor of the best-score-limit
 %test.quarkus.optaplanner.solver.termination.spent-limit=1h
 %test.quarkus.optaplanner.solver.termination.best-score-limit=0hard/*soft
+
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Always update the version also in the build.gradle. -->
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.12.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.4.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-factorio-layout/src/main/resources/application.properties
+++ b/quarkus-factorio-layout/src/main/resources/application.properties
@@ -8,3 +8,6 @@
 
 # The solver runs for 5 minutes. To run for 30 seconds use "30s" and for 2 hours use "2h".
 # quarkus.optaplanner.solver.termination.spent-limit=5m
+
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.12.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.4.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-maintenance-scheduling/src/main/resources/application.properties
+++ b/quarkus-maintenance-scheduling/src/main/resources/application.properties
@@ -64,3 +64,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:maintenance-scheduling
+
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "1.11.0.Final"
+    id "io.quarkus" version "1.12.0.Final"
 }
 
-def quarkusVersion = "1.11.0.Final"
+def quarkusVersion = "1.12.0.Final"
 def optaplannerVersion = "8.4.0-SNAPSHOT"
 
 group = "org.acme"

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.12.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.4.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-school-timetabling/src/main/resources/application.properties
+++ b/quarkus-school-timetabling/src/main/resources/application.properties
@@ -64,3 +64,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
+
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.12.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.4.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.acme</groupId>
-  <artifactId>optaplanner-quarkus-vaccination-scheduler-quickstart</artifactId>
+  <artifactId>optaplanner-quarkus-vaccination-scheduling-quickstart</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <properties>

--- a/quarkus-vaccination-scheduling/src/main/resources/application.properties
+++ b/quarkus-vaccination-scheduling/src/main/resources/application.properties
@@ -26,3 +26,6 @@ quarkus.optaplanner.solver.termination.spent-limit=5m
 
 # To detect common bugs in your code
 # quarkus.optaplanner.solver.environment-mode=FULL_ASSERT
+
+# Remove after switching to fast jar by default.
+quarkus.package.type=legacy-jar


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
Depends on https://github.com/kiegroup/optaplanner/pull/1169

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
