### PR TITLE
[8.3.x] Update snapshot version to 8.3.1-SNAPSHOT

### DIFF
--- a/build/quickstarts-distribution/pom.xml
+++ b/build/quickstarts-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.3.0.Final</version>
+    <version>8.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.3.0.Final</version>
+    <version>8.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -13,7 +13,7 @@
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.3.0.Final</version>
+    <version>8.3.1-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <!-- IMPORTANT: the individual quickstarts have no parent pom. -->

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.1</version.surefire.plugin>

--- a/quarkus-factorio-layout/pom.xml
+++ b/quarkus-factorio-layout/pom.xml
@@ -13,7 +13,7 @@
 
     <!-- Always update the version also in the build.gradle. -->
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 def quarkusVersion = "1.11.4.Final"
-def optaplannerVersion = "8.3.0.Final"
+def optaplannerVersion = "8.3.1-SNAPSHOT"
 
 group = "org.acme"
 version = "0.1.0-SNAPSHOT"

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "8.3.0.Final"
+def optaplannerVersion = "8.3.1-SNAPSHOT"
 
 group = "com.example"
 version = "0.1.0-SNAPSHOT"

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.optaplanner>8.3.0.Final</version.org.optaplanner>
+    <version.org.optaplanner>8.3.1-SNAPSHOT</version.org.optaplanner>
     <version.org.springframework.boot>2.2.6.RELEASE</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
