### PR TITLE
PLANNER-2339: Fix native build of quarkus-factorio-layout

### DIFF
--- a/quarkus-factorio-layout/src/main/java/org/acme/factoriolayout/bootstrap/FactorioDataGenerator.java
+++ b/quarkus-factorio-layout/src/main/java/org/acme/factoriolayout/bootstrap/FactorioDataGenerator.java
@@ -17,11 +17,9 @@
 package org.acme.factoriolayout.bootstrap;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +49,9 @@ public class FactorioDataGenerator {
     @Inject
     FactorioLayoutRepository factorioLayoutRepository;
 
+    @Inject
+    ObjectMapper mapper;
+
     public void generateDemoData(@Observes StartupEvent startupEvent) {
         List<Recipe> recipeList = readRecipes();
         Map<String, Recipe> recipeMap = recipeList.stream().collect(Collectors.toMap(Recipe::getId, recipe -> recipe));
@@ -65,7 +66,6 @@ public class FactorioDataGenerator {
 
     private List<Recipe> readRecipes() {
         List<Recipe> recipeList;
-        ObjectMapper mapper = new ObjectMapper();
         try {
             recipeList = mapper.readValue(
                     Thread.currentThread().getContextClassLoader().getResource(RECIPES_JSON_RESOURCE),

--- a/quarkus-factorio-layout/src/main/java/org/acme/factoriolayout/domain/Recipe.java
+++ b/quarkus-factorio-layout/src/main/java/org/acme/factoriolayout/domain/Recipe.java
@@ -21,7 +21,9 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
+@RegisterForReflection
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class,
         property = "id")
 public class Recipe {

--- a/quarkus-factorio-layout/src/main/java/org/acme/factoriolayout/domain/RecipeInput.java
+++ b/quarkus-factorio-layout/src/main/java/org/acme/factoriolayout/domain/RecipeInput.java
@@ -17,7 +17,9 @@
 package org.acme.factoriolayout.domain;
 
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
+@RegisterForReflection
 public class RecipeInput {
 
     @JsonIdentityReference(alwaysAsId = true)

--- a/quarkus-factorio-layout/src/main/resources/application.properties
+++ b/quarkus-factorio-layout/src/main/resources/application.properties
@@ -11,3 +11,10 @@
 
 # TODO: Remove after switching to fast jar by default.
 quarkus.package.type=fast-jar
+
+# Includes demo generator resources in native executable
+# TODO: Remove ReflectionConfigurationFiles and reflection-config.json once
+#       https://github.com/quarkusio/quarkus/pull/15506 is merged and
+#       the quarkus version is updated.
+quarkus.native.additional-build-args =-H:ResourceConfigurationFiles=resources-config.json,\
+  -H:ReflectionConfigurationFiles=reflection-config.json

--- a/quarkus-factorio-layout/src/main/resources/reflection-config.json
+++ b/quarkus-factorio-layout/src/main/resources/reflection-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name" : "com.fasterxml.jackson.annotation.SimpleObjectIdResolver",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  }
+]

--- a/quarkus-factorio-layout/src/main/resources/resources-config.json
+++ b/quarkus-factorio-layout/src/main/resources/resources-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "pattern": ".*\\.json$"
+    }
+  ]
+}


### PR DESCRIPTION
There is a workaround I needed to add since Quarkus Jackson doesn't support JsonIdentityInfo out of the box currently. It can be removed once https://github.com/quarkusio/quarkus/pull/15506 is merged and the Quarkus version is updated.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->
https://issues.redhat.com/browse/PLANNER-2339

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
