### PR TITLE
PLANNER-2345: Inject ConstraintVerifier into Quarkus tests

### DIFF
--- a/kotlin-quarkus-school-timetabling/src/test/kotlin/org/acme/kotlin/schooltimetabling/solver/TimeTableConstraintProviderTest.kt
+++ b/kotlin-quarkus-school-timetabling/src/test/kotlin/org/acme/kotlin/schooltimetabling/solver/TimeTableConstraintProviderTest.kt
@@ -16,6 +16,7 @@
 
 package org.acme.kotlin.schooltimetabling.solver
 
+import io.quarkus.test.junit.QuarkusTest
 import org.acme.kotlin.schooltimetabling.domain.Lesson
 import org.acme.kotlin.schooltimetabling.domain.Room
 import org.acme.kotlin.schooltimetabling.domain.TimeTable
@@ -24,8 +25,10 @@ import org.junit.jupiter.api.Test
 import org.optaplanner.test.api.score.stream.ConstraintVerifier
 import java.time.DayOfWeek
 import java.time.LocalTime
+import javax.inject.Inject
 
-internal class TimeTableConstraintProviderTest {
+@QuarkusTest
+class TimeTableConstraintProviderTest {
     
     val ROOM1: Room = Room(1, "Room1")
     val ROOM2: Room = Room(2, "Room2")
@@ -34,7 +37,8 @@ internal class TimeTableConstraintProviderTest {
     val TIMESLOT3: Timeslot = Timeslot(3, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(1), LocalTime.NOON.plusHours(1).plusMinutes(50))
     val TIMESLOT4: Timeslot = Timeslot(4, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(3), LocalTime.NOON.plusHours(3).plusMinutes(50))
 
-    val constraintVerifier: ConstraintVerifier<TimeTableConstraintProvider, TimeTable> = ConstraintVerifier.build(TimeTableConstraintProvider(), TimeTable::class.java, Lesson::class.java)
+    @Inject
+    lateinit var constraintVerifier: ConstraintVerifier<TimeTableConstraintProvider, TimeTable>;
 
     @Test
     fun roomConflict() {

--- a/quarkus-facility-location/src/test/java/org/acme/facilitylocation/domain/FacilityLocationConstraintProviderTest.java
+++ b/quarkus-facility-location/src/test/java/org/acme/facilitylocation/domain/FacilityLocationConstraintProviderTest.java
@@ -16,16 +16,17 @@
 
 package org.acme.facilitylocation.domain;
 
+import javax.inject.Inject;
+
+import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
+@QuarkusTest
 class FacilityLocationConstraintProviderTest {
 
-    private final ConstraintVerifier<FacilityLocationConstraintProvider, FacilityLocationProblem> constraintVerifier =
-            ConstraintVerifier.build(
-                    new FacilityLocationConstraintProvider(),
-                    FacilityLocationProblem.class,
-                    Consumer.class);
+    @Inject
+    ConstraintVerifier<FacilityLocationConstraintProvider, FacilityLocationProblem> constraintVerifier;
 
     @Test
     void penalizes_capacity_exceeded_by_a_single_consumer() {

--- a/quarkus-maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/solver/MaintenanceSchedulingConstraintProviderTest.java
+++ b/quarkus-maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/solver/MaintenanceSchedulingConstraintProviderTest.java
@@ -16,6 +16,9 @@
 
 package org.acme.maintenancescheduling.solver;
 
+import javax.inject.Inject;
+
+import io.quarkus.test.junit.QuarkusTest;
 import org.acme.maintenancescheduling.domain.MaintainableUnit;
 import org.acme.maintenancescheduling.domain.MaintenanceCrew;
 import org.acme.maintenancescheduling.domain.MaintenanceJob;
@@ -25,11 +28,11 @@ import org.acme.maintenancescheduling.domain.TimeGrain;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
+@QuarkusTest
 public class MaintenanceSchedulingConstraintProviderTest {
 
-    private final ConstraintVerifier<MaintenanceScheduleConstraintProvider, MaintenanceSchedule> constraintVerifier =
-            ConstraintVerifier.build(new MaintenanceScheduleConstraintProvider(), MaintenanceSchedule.class,
-                    MaintenanceJob.class);
+    @Inject
+    ConstraintVerifier<MaintenanceScheduleConstraintProvider, MaintenanceSchedule> constraintVerifier;
 
     @Test
     public void jobsMustStartAfterReadyTimeGrainUnpenalized() {

--- a/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java
+++ b/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java
@@ -19,6 +19,9 @@ package org.acme.schooltimetabling.solver;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
+import javax.inject.Inject;
+
+import io.quarkus.test.junit.QuarkusTest;
 import org.acme.schooltimetabling.domain.Lesson;
 import org.acme.schooltimetabling.domain.Room;
 import org.acme.schooltimetabling.domain.TimeTable;
@@ -26,6 +29,7 @@ import org.acme.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
+@QuarkusTest
 class TimeTableConstraintProviderTest {
 
     private static final Room ROOM1 = new Room(1, "Room1");
@@ -35,8 +39,8 @@ class TimeTableConstraintProviderTest {
     private static final Timeslot TIMESLOT3 = new Timeslot(3, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(1));
     private static final Timeslot TIMESLOT4 = new Timeslot(4, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(3));
 
-    private final ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier =
-            ConstraintVerifier.build(new TimeTableConstraintProvider(), TimeTable.class, Lesson.class);
+    @Inject
+    ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier;
 
     @Test
     void roomConflict() {

--- a/quarkus-vaccination-scheduling/src/test/java/org/acme/vaccinationscheduler/solver/VaccinationScheduleConstraintProviderTest.java
+++ b/quarkus-vaccination-scheduling/src/test/java/org/acme/vaccinationscheduler/solver/VaccinationScheduleConstraintProviderTest.java
@@ -19,6 +19,9 @@ package org.acme.vaccinationscheduler.solver;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.inject.Inject;
+
+import io.quarkus.test.junit.QuarkusTest;
 import org.acme.vaccinationscheduler.domain.Injection;
 import org.acme.vaccinationscheduler.domain.Location;
 import org.acme.vaccinationscheduler.domain.Person;
@@ -28,6 +31,7 @@ import org.acme.vaccinationscheduler.domain.VaccineType;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
 
+@QuarkusTest
 class VaccinationScheduleConstraintProviderTest {
 
     private static final VaccineType PFIZER = new VaccineType("Pfizer", 19, 21);
@@ -52,8 +56,8 @@ class VaccinationScheduleConstraintProviderTest {
     private static final Person CARL = new Person(3, "Carl", new Location(3, 0), LocalDate.of(1970, 1, 1), 51,
             true, MODERNA, THURSDAY.minusDays(28));
 
-    private final ConstraintVerifier<VaccinationScheduleConstraintProvider, VaccinationSchedule> constraintVerifier =
-            ConstraintVerifier.build(new VaccinationScheduleConstraintProvider(), VaccinationSchedule.class, Injection.class);
+    @Inject
+    ConstraintVerifier<VaccinationScheduleConstraintProvider, VaccinationSchedule> constraintVerifier;
 
     @Test
     void personConflict() {


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2345

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
