### PR TITLE
PLANNER-2345: Autowire ConstraintVerifier in Spring Boot tests

### DIFF
--- a/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableConstraintProviderTest.java
+++ b/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableConstraintProviderTest.java
@@ -25,7 +25,10 @@ import com.example.schooltimetabling.domain.TimeTable;
 import com.example.schooltimetabling.domain.Timeslot;
 import org.junit.jupiter.api.Test;
 import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest
 class TimeTableConstraintProviderTest {
 
     private static final Room ROOM1 = new Room(1, "Room1");
@@ -35,8 +38,8 @@ class TimeTableConstraintProviderTest {
     private static final Timeslot TIMESLOT3 = new Timeslot(3, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(1));
     private static final Timeslot TIMESLOT4 = new Timeslot(4, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(3));
 
-    private final ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier =
-            ConstraintVerifier.build(new TimeTableConstraintProvider(), TimeTable.class, Lesson.class);
+    @Autowired
+    ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier;
 
     @Test
     void roomConflict() {


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2345

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
