### PR TITLE
PLANNER-2366: Upgrade Spring Boot to 2.3.4

### DIFF
--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.springframework.boot" version "2.2.6.RELEASE"
+    id "org.springframework.boot" version "2.3.4.RELEASE"
     id "io.spring.dependency-management" version "1.0.9.RELEASE"
     id "java"
 }

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.org.optaplanner>8.5.0-SNAPSHOT</version.org.optaplanner>
-    <version.org.springframework.boot>2.2.6.RELEASE</version.org.springframework.boot>
+    <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2366

### Referenced pull requests
- https://github.com/kiegroup/optaplanner/pull/1221
- https://github.com/kiegroup/optaplanner-quickstarts/pull/78
