### PR TITLE
Override compiler-maven-plugin version

### DIFF
--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -14,6 +14,8 @@
 
   <properties>
     <java.module.name>org.optaplanner.quickstarts.showcase</java.module.name>
+    <!-- Workaround for https://github.com/quarkusio/quarkus/issues/15817. -->
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
A workaround for https://github.com/quarkusio/quarkus/issues/15817.

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
