### PR TITLE
Log test execution in Gradle build

### DIFF
--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -61,4 +61,8 @@ test {
     // Gradle needs native tests in src/native-test/java, but maven needs them in src/test/java instead.
     // Maven first, so we skip them in Gradle unfortunately.
     exclude '**/**IT.class'
+    // Log the test execution results.
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -39,4 +39,8 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    // Log the test execution results.
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }


### PR DESCRIPTION
Improves a bit the test execution logging.
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
