### PR TITLE
PLANNER-2389 Upgrade Quarkus to 1.13

### DIFF
--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-client/src/main/resources/application.properties
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-client/src/main/resources/application.properties
@@ -35,6 +35,3 @@ mp.messaging.outgoing.solver_request.durable=true
 # Configure the Kafka source to read from it
 mp.messaging.incoming.solver_response.connector=smallrye-amqp
 mp.messaging.incoming.solver_response.durable=true
-
-# TODO: Remove after upgrading to Quarkus 1.12 or higher which uses fast-jar by default.
-quarkus.package.type=fast-jar

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/src/test/resources/application.properties
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/src/test/resources/application.properties
@@ -35,6 +35,3 @@ mp.messaging.incoming.solver_request.failure-strategy=reject
 # Configure the ActiveMQ sink (we write to it)
 mp.messaging.outgoing.solver_response.connector=smallrye-amqp
 mp.messaging.outgoing.solver_response.durable=true
-
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar

--- a/activemq-quarkus-school-timetabling/pom.xml
+++ b/activemq-quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/build/quickstarts-showcase/src/main/resources/application.properties
+++ b/build/quickstarts-showcase/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.0.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 

--- a/kotlin-quarkus-school-timetabling/src/main/resources/application.properties
+++ b/kotlin-quarkus-school-timetabling/src/main/resources/application.properties
@@ -52,6 +52,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
-
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar

--- a/quarkus-call-center/pom.xml
+++ b/quarkus-call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-facility-location/src/main/resources/application.properties
+++ b/quarkus-facility-location/src/main/resources/application.properties
@@ -27,6 +27,3 @@ quarkus.log.category."org.optaplanner".level=DEBUG
 # Effectively disable this termination in favor of the best-score-limit
 %test.quarkus.optaplanner.solver.termination.spent-limit=1h
 %test.quarkus.optaplanner.solver.termination.best-score-limit=0hard/*soft
-
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-maintenance-scheduling/src/main/resources/application.properties
+++ b/quarkus-maintenance-scheduling/src/main/resources/application.properties
@@ -52,6 +52,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:maintenance-scheduling
-
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "1.11.4.Final"
+    id "io.quarkus" version "1.13.3.Final"
 }
 
-def quarkusVersion = "1.11.4.Final"
+def quarkusVersion = "1.13.3.Final"
 def optaplannerVersion = "8.7.0-SNAPSHOT"
 
 group = "org.acme"

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-school-timetabling/src/main/resources/application.properties
+++ b/quarkus-school-timetabling/src/main/resources/application.properties
@@ -52,6 +52,3 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
-
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.11.4.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
     <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-vaccination-scheduling/src/main/resources/application.properties
+++ b/quarkus-vaccination-scheduling/src/main/resources/application.properties
@@ -31,6 +31,3 @@ quarkus.optaplanner.solver.termination.spent-limit=5m
 quarkus.log.category."org.optaplanner".level=DEBUG
 %test.quarkus.log.category."org.optaplanner".level=INFO
 %prod.quarkus.log.category."org.optaplanner".level=INFO
-
-# TODO: Remove after switching to fast jar by default.
-quarkus.package.type=fast-jar


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2389

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1254
https://github.com/kiegroup/optaplanner-quickstarts/pull/93
https://github.com/kiegroup/optaweb-employee-rostering/pull/602
https://github.com/kiegroup/optaweb-vehicle-routing/pull/471

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
