### PR TITLE
PLANNER-2393 activemq-quarkus-school-timetabling-solver lacks a TimeTableConstraintProviderTest

### DIFF
--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-client/pom.xml
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-client/pom.xml
@@ -4,19 +4,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>activemq-quarkus-school-timetabling</artifactId>
+    <artifactId>optaplanner-activemq-quarkus-school-timetabling</artifactId>
     <groupId>org.acme</groupId>
     <version>1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>activemq-quarkus-school-timetabling-client</artifactId>
+  <artifactId>optaplanner-activemq-quarkus-school-timetabling-client</artifactId>
   <description>ActiveMQ Quarkus School Timetabling Quickstart : Client</description>
 
   <dependencies>
     <dependency>
       <groupId>org.acme</groupId>
-      <artifactId>activemq-quarkus-school-timetabling-common</artifactId>
+      <artifactId>optaplanner-activemq-quarkus-school-timetabling-common</artifactId>
       <exclusions>
         <!-- Avoid bootstrapping the optaplanner-quarkus extension. -->
         <exclusion>

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-common/pom.xml
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-common/pom.xml
@@ -4,13 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>activemq-quarkus-school-timetabling</artifactId>
+    <artifactId>optaplanner-activemq-quarkus-school-timetabling</artifactId>
     <groupId>org.acme</groupId>
     <version>1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>activemq-quarkus-school-timetabling-common</artifactId>
+  <artifactId>optaplanner-activemq-quarkus-school-timetabling-common</artifactId>
   <description>ActiveMQ Quarkus School Timetabling Quickstart : Common</description>
 
   <dependencies>

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-common/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-common/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -46,6 +46,12 @@ public class Lesson {
         this.studentGroup = studentGroup.trim();
     }
 
+    public Lesson(long id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {
+        this(id, subject, teacher, studentGroup);
+        this.timeslot = timeslot;
+        this.room = room;
+    }
+
     @Override
     public String toString() {
         return subject + "(" + id + ")";

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-common/src/main/java/org/acme/schooltimetabling/domain/Timeslot.java
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-common/src/main/java/org/acme/schooltimetabling/domain/Timeslot.java
@@ -41,6 +41,10 @@ public class Timeslot {
         this.id = id;
     }
 
+    public Timeslot(long id, DayOfWeek dayOfWeek, LocalTime startTime) {
+        this(id, dayOfWeek, startTime, startTime.plusMinutes(50));
+    }
+
     @Override
     public String toString() {
         return dayOfWeek + " " + startTime;

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/pom.xml
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/pom.xml
@@ -4,19 +4,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>activemq-quarkus-school-timetabling</artifactId>
+    <artifactId>optaplanner-activemq-quarkus-school-timetabling</artifactId>
     <groupId>org.acme</groupId>
     <version>1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>activemq-quarkus-school-timetabling-solver</artifactId>
+  <artifactId>optaplanner-activemq-quarkus-school-timetabling-solver</artifactId>
   <description>ActiveMQ Quarkus School Timetabling Quickstart : Solver Server</description>
 
   <dependencies>
     <dependency>
       <groupId>org.acme</groupId>
-      <artifactId>activemq-quarkus-school-timetabling-common</artifactId>
+      <artifactId>optaplanner-activemq-quarkus-school-timetabling-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/pom.xml
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java
+++ b/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/src/test/java/org/acme/schooltimetabling/solver/TimeTableConstraintProviderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.acme.schooltimetabling.solver;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import javax.inject.Inject;
+
+import org.acme.schooltimetabling.domain.Lesson;
+import org.acme.schooltimetabling.domain.Room;
+import org.acme.schooltimetabling.domain.Timeslot;
+import org.acme.schooltimetabling.domain.TimeTable;
+import org.junit.jupiter.api.Test;
+import org.optaplanner.test.api.score.stream.ConstraintVerifier;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+class TimeTableConstraintProviderTest {
+
+    private static final Room ROOM1 = new Room(1, "Room1");
+    private static final Room ROOM2 = new Room(2, "Room2");
+    private static final Timeslot TIMESLOT1 = new Timeslot(1, DayOfWeek.MONDAY, LocalTime.NOON);
+    private static final Timeslot TIMESLOT2 = new Timeslot(2, DayOfWeek.TUESDAY, LocalTime.NOON);
+    private static final Timeslot TIMESLOT3 = new Timeslot(3, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(1));
+    private static final Timeslot TIMESLOT4 = new Timeslot(4, DayOfWeek.TUESDAY, LocalTime.NOON.plusHours(3));
+
+    @Inject
+    ConstraintVerifier<TimeTableConstraintProvider, TimeTable> constraintVerifier;
+
+    @Test
+    void roomConflict() {
+        Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", "Group1", TIMESLOT1, ROOM1);
+        Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", "Group2", TIMESLOT1, ROOM1);
+        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3", TIMESLOT2, ROOM1);
+        constraintVerifier.verifyThat(TimeTableConstraintProvider::roomConflict)
+                .given(firstLesson, conflictingLesson, nonConflictingLesson)
+                .penalizesBy(1);
+    }
+
+    @Test
+    void teacherConflict() {
+        String conflictingTeacher = "Teacher1";
+        Lesson firstLesson = new Lesson(1, "Subject1", conflictingTeacher, "Group1", TIMESLOT1, ROOM1);
+        Lesson conflictingLesson = new Lesson(2, "Subject2", conflictingTeacher, "Group2", TIMESLOT1, ROOM2);
+        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher2", "Group3", TIMESLOT2, ROOM1);
+        constraintVerifier.verifyThat(TimeTableConstraintProvider::teacherConflict)
+                .given(firstLesson, conflictingLesson, nonConflictingLesson)
+                .penalizesBy(1);
+    }
+
+    @Test
+    void studentGroupConflict() {
+        String conflictingGroup = "Group1";
+        Lesson firstLesson = new Lesson(1, "Subject1", "Teacher1", conflictingGroup, TIMESLOT1, ROOM1);
+        Lesson conflictingLesson = new Lesson(2, "Subject2", "Teacher2", conflictingGroup, TIMESLOT1, ROOM2);
+        Lesson nonConflictingLesson = new Lesson(3, "Subject3", "Teacher3", "Group3", TIMESLOT2, ROOM1);
+        constraintVerifier.verifyThat(TimeTableConstraintProvider::studentGroupConflict)
+                .given(firstLesson, conflictingLesson, nonConflictingLesson)
+                .penalizesBy(1);
+    }
+
+    @Test
+    void teacherRoomStability() {
+        String teacher = "Teacher1";
+        Lesson lessonInFirstRoom = new Lesson(1, "Subject1", teacher, "Group1", TIMESLOT1, ROOM1);
+        Lesson lessonInSameRoom = new Lesson(2, "Subject2", teacher, "Group2", TIMESLOT1, ROOM1);
+        Lesson lessonInDifferentRoom = new Lesson(3, "Subject3", teacher, "Group3", TIMESLOT1, ROOM2);
+        constraintVerifier.verifyThat(TimeTableConstraintProvider::teacherRoomStability)
+                .given(lessonInFirstRoom, lessonInDifferentRoom, lessonInSameRoom)
+                .penalizesBy(2);
+    }
+
+    @Test
+    void teacherTimeEfficiency() {
+        String teacher = "Teacher1";
+        Lesson singleLessonOnMonday = new Lesson(1, "Subject1", teacher, "Group1", TIMESLOT1, ROOM1);
+        Lesson firstTuesdayLesson = new Lesson(2, "Subject2", teacher, "Group2", TIMESLOT2, ROOM1);
+        Lesson secondTuesdayLesson = new Lesson(3, "Subject3", teacher, "Group3", TIMESLOT3, ROOM1);
+        Lesson thirdTuesdayLessonWithGap = new Lesson(4, "Subject4", teacher, "Group4", TIMESLOT4, ROOM1);
+        constraintVerifier.verifyThat(TimeTableConstraintProvider::teacherTimeEfficiency)
+                .given(singleLessonOnMonday, firstTuesdayLesson, secondTuesdayLesson, thirdTuesdayLessonWithGap)
+                .rewardsWith(1); // Second tuesday lesson immediately follows the first.
+    }
+
+    @Test
+    void studentGroupSubjectVariety() {
+        String studentGroup = "Group1";
+        String repeatedSubject = "Subject1";
+        Lesson mondayLesson = new Lesson(1, repeatedSubject, "Teacher1", studentGroup, TIMESLOT1, ROOM1);
+        Lesson firstTuesdayLesson = new Lesson(2, repeatedSubject, "Teacher2", studentGroup, TIMESLOT2, ROOM1);
+        Lesson secondTuesdayLesson = new Lesson(3, repeatedSubject, "Teacher3", studentGroup, TIMESLOT3, ROOM1);
+        Lesson thirdTuesdayLessonWithDifferentSubject = new Lesson(4, "Subject2", "Teacher4", studentGroup, TIMESLOT4, ROOM1);
+        Lesson lessonInAnotherGroup = new Lesson(5, repeatedSubject, "Teacher5", "Group2", TIMESLOT1, ROOM1);
+        constraintVerifier.verifyThat(TimeTableConstraintProvider::studentGroupSubjectVariety)
+                .given(mondayLesson, firstTuesdayLesson, secondTuesdayLesson, thirdTuesdayLessonWithDifferentSubject,
+                        lessonInAnotherGroup)
+                .penalizesBy(1); // Second tuesday lesson immediately follows the first.
+    }
+
+}

--- a/activemq-quarkus-school-timetabling/pom.xml
+++ b/activemq-quarkus-school-timetabling/pom.xml
@@ -96,6 +96,11 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.jboss.jandex</groupId>
+          <artifactId>jandex-maven-plugin</artifactId>
+          <version>1.0.8</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire-plugin.version}</version>
           <configuration>

--- a/activemq-quarkus-school-timetabling/pom.xml
+++ b/activemq-quarkus-school-timetabling/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.acme</groupId>
-  <artifactId>activemq-quarkus-school-timetabling</artifactId>
+  <artifactId>optaplanner-activemq-quarkus-school-timetabling</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
@@ -45,7 +45,7 @@
       </dependency>
       <dependency>
         <groupId>org.acme</groupId>
-        <artifactId>activemq-quarkus-school-timetabling-common</artifactId>
+        <artifactId>optaplanner-activemq-quarkus-school-timetabling-common</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2393
<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
