### PR TITLE
[development] Update project version to 8.7.0-SNAPSHOT

### DIFF
--- a/activemq-quarkus-school-timetabling/pom.xml
+++ b/activemq-quarkus-school-timetabling/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/build/quickstarts-distribution/pom.xml
+++ b/build/quickstarts-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.6.0-SNAPSHOT</version>
+    <version>8.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.6.0-SNAPSHOT</version>
+    <version>8.7.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -13,7 +13,7 @@
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
     <version.kotlin>1.3.72</version.kotlin>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.6.0-SNAPSHOT</version>
+    <version>8.7.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <!-- IMPORTANT: the individual quickstarts have no parent pom. -->

--- a/quarkus-call-center/pom.xml
+++ b/quarkus-call-center/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.acme</groupId>
@@ -13,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.13.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
@@ -106,7 +105,6 @@
       <version>1.11.0</version>
       <scope>runtime</scope>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -170,8 +168,6 @@
       </build>
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
-        <!-- To allow application.properties to avoid using the in-memory database for native builds. -->
-        <quarkus.profile>native</quarkus.profile>
       </properties>
     </profile>
   </profiles>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.1</version.surefire.plugin>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 def quarkusVersion = "1.11.4.Final"
-def optaplannerVersion = "8.6.0-SNAPSHOT"
+def optaplannerVersion = "8.7.0-SNAPSHOT"
 
 group = "org.acme"
 version = "0.1.0-SNAPSHOT"

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>1.11.4.Final</version.io.quarkus>
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "8.6.0-SNAPSHOT"
+def optaplannerVersion = "8.7.0-SNAPSHOT"
 
 group = "com.example"
 version = "0.1.0-SNAPSHOT"

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.optaplanner>8.6.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.7.0-SNAPSHOT</version.org.optaplanner>
     <version.org.springframework.boot>2.4.5</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

Replaces https://github.com/kiegroup/optaplanner-quickstarts/pull/100 to resolve merge conflicts.

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
