### PR TITLE
Fix Font Awesome icons in Facility Location quickstart

### DIFF
--- a/quarkus-facility-location/src/main/resources/META-INF/resources/app.js
+++ b/quarkus-facility-location/src/main/resources/META-INF/resources/app.js
@@ -196,7 +196,7 @@ const showProblem = ({solution, scoreExplanation, isSolving}) => {
     marker.setIcon(icon);
     marker.setPopupContent(facilityPopupContent(facility, longCostFormat.format(facility.setupCost), color));
     facilitiesTable.append(`<tr class="${used ? 'table-active' : 'text-muted'}">
-<td><i class="fa fa-crosshairs" id="crosshairs-${id}"
+<td><i class="fas fa-crosshairs" id="crosshairs-${id}"
 style="background-color: ${colorIfUsed}; display: inline-block; width: 1rem; height: 1rem; text-align: center">
 </i></td><td>Facility ${id}</td>
 <td><div class="progress">

--- a/quarkus-facility-location/src/main/resources/META-INF/resources/index.html
+++ b/quarkus-facility-location/src/main/resources/META-INF/resources/index.html
@@ -23,7 +23,7 @@
 
   <link rel="stylesheet" href="/webjars/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="/webjars/leaflet/leaflet.css">
-  <link rel="stylesheet" href="/webjars/font-awesome/css/font-awesome.min.css">
+  <link rel="stylesheet" href="/webjars/font-awesome/css/all.min.css">
 
   <title>Facility location - OptaPlanner Quarkus</title>
 </head>
@@ -42,17 +42,17 @@
       <div class="row pt-2 row-cols-1">
         <div class="col mb-3">
           <button id="solveButton" type="button" class="btn btn-success">
-            <i class="fa fa-play"></i> Solve
+            <i class="fas fa-play"></i> Solve
           </button>
           <button id="stopSolvingButton" type="button" class="btn btn-danger">
-            <i class="fa fa-stop"></i> Stop solving
+            <i class="fas fa-stop"></i> Stop solving
           </button>
         </div>
         <div class="col">
           <h5>
             Solution summary
             <a href="#" class="float-right" data-toggle="modal" data-target="#scoreDialog">
-              <i class="fa fa-info-circle"></i>
+              <i class="fas fa-info-circle"></i>
             </a>
           </h5>
           <table class="table">


### PR DESCRIPTION
Fix a regression caused by #30.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
