### PR TITLE
PLANNER-2341: Add benchmarking example to Quarkus and Spring Boot School Timetabling

### DIFF
--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}")
     implementation "org.optaplanner:optaplanner-quarkus:${optaplannerVersion}"
     implementation "org.optaplanner:optaplanner-quarkus-jackson:${optaplannerVersion}"
+    implementation "org.optaplanner:optaplanner-quarkus-benchmark:${optaplannerVersion}"
     implementation "org.optaplanner:optaplanner-test:${optaplannerVersion}"
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-resteasy-jackson'

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -90,6 +90,11 @@
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-quarkus-benchmark</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- UI -->
     <dependency>

--- a/quarkus-school-timetabling/src/main/resources/application.properties
+++ b/quarkus-school-timetabling/src/main/resources/application.properties
@@ -40,6 +40,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # Test overrides
 ########################
 
+%test.quarkus.optaplanner.benchmark.solver.termination.spent-limit=15s
 %test.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
 
 # Effectively disable this termination in favor of the best-score-limit

--- a/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/solver/TimeTableBenchmarkTest.java
+++ b/quarkus-school-timetabling/src/test/java/org/acme/schooltimetabling/solver/TimeTableBenchmarkTest.java
@@ -1,0 +1,24 @@
+package org.acme.schooltimetabling.solver;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.acme.schooltimetabling.rest.TimeTableResource;
+import org.junit.jupiter.api.Test;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+
+import javax.inject.Inject;
+
+@QuarkusTest
+public class TimeTableBenchmarkTest {
+
+    @Inject
+    PlannerBenchmarkFactory benchmarkFactory;
+
+    @Inject
+    TimeTableResource timeTableResource;
+
+    @Test
+    public void benchmark() {
+        benchmarkFactory.buildPlannerBenchmark(timeTableResource.getTimeTable())
+                .benchmark();
+    }
+}

--- a/spring-boot-school-timetabling/build.gradle
+++ b/spring-boot-school-timetabling/build.gradle
@@ -35,6 +35,7 @@ dependencies {
         exclude group: "org.junit.vintage", module: "junit-vintage-engine"
     }
     testImplementation("org.optaplanner:optaplanner-test:${optaplannerVersion}")
+    testImplementation("org.optaplanner:optaplanner-benchmark:${optaplannerVersion}")
 }
 
 test {

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-benchmark</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/spring-boot-school-timetabling/src/main/resources/application.properties
+++ b/spring-boot-school-timetabling/src/main/resources/application.properties
@@ -5,6 +5,9 @@
 # The solver runs for 30 seconds. To run for 5 minutes use "5m" and for 2 hours use "2h".
 optaplanner.solver.termination.spent-limit=30s
 
+# When benchmarking, each individual solver runs for 15 seconds. To run for 5 minutes use "5m" and for 2 hours use "2h".
+optaplanner.benchmark.solver.termination.spent-limit=15s
+
 # To change how many solvers to run in parallel
 # optaplanner.solver-manager.parallel-solver-count=4
 # To run increase CPU cores usage per solver

--- a/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableBenchmarkTest.java
+++ b/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableBenchmarkTest.java
@@ -1,0 +1,26 @@
+package com.example.schooltimetabling.solver;
+
+import com.example.schooltimetabling.rest.TimeTableController;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = {
+        "optaplanner.benchmark.solver.termination.spent-limit=10s",
+})
+public class TimeTableBenchmarkTest {
+
+    @Autowired
+    private TimeTableController timeTableController;
+
+    @Autowired
+    private PlannerBenchmarkFactory benchmarkFactory;
+
+    @Test
+    @Timeout(600_000)
+    public void benchmark() {
+        benchmarkFactory.buildPlannerBenchmark(timeTableController.getTimeTable()).benchmark();
+    }
+}

--- a/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableBenchmarkTest.java
+++ b/spring-boot-school-timetabling/src/test/java/com/example/schooltimetabling/solver/TimeTableBenchmarkTest.java
@@ -7,9 +7,7 @@ import org.optaplanner.benchmark.api.PlannerBenchmarkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(properties = {
-        "optaplanner.benchmark.solver.termination.spent-limit=10s",
-})
+@SpringBootTest
 public class TimeTableBenchmarkTest {
 
     @Autowired


### PR DESCRIPTION
Depends on https://github.com/kiegroup/optaplanner/pull/1249
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
* https://github.com/kiegroup/optaplanner/pull/1249
