### PR TITLE
Add ActiveMQ quickstart to distribution

### DIFF
--- a/build/quickstarts-distribution/src/main/assembly/assembly-optaplanner-quickstarts.xml
+++ b/build/quickstarts-distribution/src/main/assembly/assembly-optaplanner-quickstarts.xml
@@ -83,6 +83,28 @@
         <include>quarkus-app/**</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>../../activemq-quarkus-school-timetabling</directory>
+      <outputDirectory>binaries/activemq-quarkus-school-timetabling</outputDirectory>
+      <includes>
+        <include>broker-*.xml</include>
+        <include>docker-compose.yml</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>../../activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-client/target</directory>
+      <outputDirectory>binaries/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-client</outputDirectory>
+      <includes>
+        <include>quarkus-app/**</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>../../activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver/target</directory>
+      <outputDirectory>binaries/activemq-quarkus-school-timetabling/activemq-quarkus-school-timetabling-solver</outputDirectory>
+      <includes>
+        <include>quarkus-app/**</include>
+      </includes>
+    </fileSet>
   </fileSets>
 
 </assembly>

--- a/build/quickstarts-distribution/src/main/assembly/sources.xml
+++ b/build/quickstarts-distribution/src/main/assembly/sources.xml
@@ -83,6 +83,15 @@
         <exclude>.gitignore</exclude>
       </excludes>
     </fileSet>
+    <fileSet>
+      <useDefaultExcludes>false</useDefaultExcludes>
+      <directory>../../activemq-quarkus-school-timetabling</directory>
+      <outputDirectory>sources/activemq-quarkus-school-timetabling</outputDirectory>
+      <excludes>
+        <exclude>**/target/**</exclude>
+        <exclude>.gitignore</exclude>
+      </excludes>
+    </fileSet>
   </fileSets>
 
 </component>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
