### PR TITLE
Upgrade Quarkus to 2.0.0.Final

### DIFF
--- a/activemq-quarkus-school-timetabling/pom.xml
+++ b/activemq-quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -11,8 +11,9 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
-    <version.kotlin>1.3.72</version.kotlin>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
+    <!-- The version 1.4.32 Quarkus uses does not work with Java 16. -->
+    <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/kotlin-quarkus-school-timetabling/pom.xml
+++ b/kotlin-quarkus-school-timetabling/pom.xml
@@ -12,7 +12,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.0.0.Final</version.io.quarkus>
-    <!-- The version 1.4.32 Quarkus uses does not work with Java 16. -->
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 

--- a/quarkus-call-center/pom.xml
+++ b/quarkus-call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-facility-location/pom.xml
+++ b/quarkus-facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-maintenance-scheduling/pom.xml
+++ b/quarkus-maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-school-timetabling/build.gradle
+++ b/quarkus-school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "1.13.4.Final"
+    id "io.quarkus" version "2.0.0.Final"
 }
 
-def quarkusVersion = "1.13.4.Final"
+def quarkusVersion = "2.0.0.Final"
 def optaplannerVersion = "8.9.0-SNAPSHOT"
 
 group = "org.acme"

--- a/quarkus-school-timetabling/pom.xml
+++ b/quarkus-school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/quarkus-vaccination-scheduling/pom.xml
+++ b/quarkus-vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>1.13.4.Final</version.io.quarkus>
+    <version.io.quarkus>2.0.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.9.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -15,7 +15,8 @@
     <version.org.springframework.boot>2.4.5</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>2.22.2</version.surefire.plugin>
+    <!-- The version 2.22.2 fails when the tests run from the top-level project. -->
+    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/spring-boot-school-timetabling/pom.xml
+++ b/spring-boot-school-timetabling/pom.xml
@@ -15,7 +15,6 @@
     <version.org.springframework.boot>2.4.5</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <!-- The version 2.22.2 fails when the tests run from the top-level project. -->
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>
 


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
