### PR TITLE
Downgrade Quarkus for the ActiveMQ quickstart

### DIFF
--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,8 @@
 
   <properties>
     <version.org.optaplanner>8.10.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>2.1.0.Final</version.io.quarkus>
+    <!-- TODO: Upgrade after https://issues.redhat.com/browse/PLANNER-2489 gets fixed. -->
+    <version.io.quarkus>2.0.1.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>


### PR DESCRIPTION
Temporarily downgrading the Quarkus version for the ActiveMQ quickstart.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2489

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
