### PR TITLE
Disable persistence of ActiveMQ broker in tests

### DIFF
--- a/technology/java-activemq-quarkus/solver/src/test/resources/broker.xml
+++ b/technology/java-activemq-quarkus/solver/src/test/resources/broker.xml
@@ -8,7 +8,7 @@
 
     <name>0.0.0.0</name>
 
-    <persistence-enabled>true</persistence-enabled>
+    <persistence-enabled>false</persistence-enabled>
     <journal-type>NIO</journal-type>
     <paging-directory>target/data/paging</paging-directory>
     <bindings-directory>target/data/bindings</bindings-directory>


### PR DESCRIPTION
During debugging in IntelliJ IDEA, it happens that test methods of the `TimeTableMessagingHandlerTest`, if stopped via debugging console, may influence each other as the messages they produce stay in the embedded ActiveMQ broker. Disabling the persistence of messages solves the issue.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/master/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
