### PR TITLE
Fine-tune call-center parameters

### DIFF
--- a/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
@@ -38,13 +38,13 @@ public class DataGenerator {
     private final Random RANDOM = new Random(37);
 
     private static final Agent[] AGENTS = new Agent[] {
-            new Agent(nextId(), "Ann", buildSkillSet(Skill.ENGLISH, Skill.LIFE_INSURANCE)),
-            new Agent(nextId(), "Beth", buildSkillSet(Skill.ENGLISH, Skill.CAR_INSURANCE)),
+            new Agent(nextId(), "Ann", buildSkillSet(Skill.ENGLISH, Skill.LIFE_INSURANCE, Skill.PROPERTY_INSURANCE)),
+            new Agent(nextId(), "Beth", buildSkillSet(Skill.ENGLISH, Skill.SPANISH, Skill.CAR_INSURANCE)),
             new Agent(nextId(), "Carl", buildSkillSet(Skill.ENGLISH, Skill.PROPERTY_INSURANCE)),
             new Agent(nextId(), "Dennis", buildSkillSet(Skill.SPANISH, Skill.LIFE_INSURANCE)),
-            new Agent(nextId(), "Elsa", buildSkillSet(Skill.SPANISH, Skill.CAR_INSURANCE)),
+            new Agent(nextId(), "Elsa", buildSkillSet(Skill.SPANISH, Skill.CAR_INSURANCE, Skill.PROPERTY_INSURANCE)),
             new Agent(nextId(), "Francis", buildSkillSet(Skill.SPANISH, Skill.PROPERTY_INSURANCE)),
-            new Agent(nextId(), "Gus", buildSkillSet(Skill.GERMAN, Skill.LIFE_INSURANCE)),
+            new Agent(nextId(), "Gus", buildSkillSet(Skill.GERMAN, Skill.ENGLISH, Skill.LIFE_INSURANCE)),
             new Agent(nextId(), "Hugo", buildSkillSet(Skill.GERMAN, Skill.CAR_INSURANCE, Skill.PROPERTY_INSURANCE))
     };
 

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/service/SimulationService.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/service/SimulationService.java
@@ -48,8 +48,8 @@ public class SimulationService {
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     // Initial simulation values that are overridden by a client.
-    private int durationSeconds = 10;
-    private int frequencyPerMinute = 10;
+    private int durationSeconds = 30;
+    private int frequencyPerMinute = 25;
 
     private ScheduledFuture<?> addNewCallScheduledFuture;
 

--- a/use-cases/call-center/src/main/resources/META-INF/resources/index.html
+++ b/use-cases/call-center/src/main/resources/META-INF/resources/index.html
@@ -49,12 +49,12 @@
             <div class="row">
                 <div class="col-md-6">
                     <p><span id="callFrequencyValue"></span> new calls per minute</p>
-                    <input type="range" min="0" max="60" value="10" id="callFrequencyRange"/>
+                    <input type="range" min="0" max="60" value="25" id="callFrequencyRange"/>
                 </div>
 
                 <div class="col-md-6">
                     <p>Call duration <span id="callLengthValue"></span> seconds</p>
-                    <input type="range" min="10" max="60" value="10" id="callLengthRange"/>
+                    <input type="range" min="10" max="60" value="30" id="callLengthRange"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Change call center quickstart simulation parameters to make presentations more fluent.

Right now, the agents' skills do not allow balancing calls between agents much. Also, the frequency and the length of calls are too low to create waiting calls and show the benefit of optimization.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
