### PR TITLE
Upgrade Quarkus to 2.2.0.Final

### DIFF
--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
 

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.1.2.Final"
+    id "io.quarkus" version "2.2.0.Final"
 }
 
-def quarkusVersion = "2.1.2.Final"
+def quarkusVersion = "2.2.0.Final"
 def optaplannerVersion = "8.12.0-SNAPSHOT"
 
 group = "org.acme"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.1.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.2.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.12.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1530
https://github.com/kiegroup/optaplanner-quickstarts/pull/166

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
