### PR TITLE
Use platform dependency in gradle files

### DIFF
--- a/hello-world/build.gradle
+++ b/hello-world/build.gradle
@@ -21,10 +21,11 @@ repositories {
 }
 
 dependencies {
-    implementation "org.optaplanner:optaplanner-core:${optaplannerVersion}"
+    implementation platform ("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
+    implementation "org.optaplanner:optaplanner-core"
     runtimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 
-    testImplementation "org.optaplanner:optaplanner-test:${optaplannerVersion}"
+    testImplementation "org.optaplanner:optaplanner-test"
 }
 
 java {

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -22,10 +22,10 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-data-rest"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    implementation enforcedPlatform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     runtimeOnly "com.h2database:h2"
     implementation "org.optaplanner:optaplanner-spring-boot-starter"
     runtimeOnly "org.webjars:webjars-locator:0.37"

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -22,11 +22,12 @@ repositories {
 }
 
 dependencies {
+    implementation enforcedPlatform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-data-rest"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     runtimeOnly "com.h2database:h2"
-    implementation "org.optaplanner:optaplanner-spring-boot-starter:${optaplannerVersion}"
+    implementation "org.optaplanner:optaplanner-spring-boot-starter"
     runtimeOnly "org.webjars:webjars-locator:0.37"
     runtimeOnly "org.webjars:bootstrap:4.3.1"
     runtimeOnly "org.webjars:font-awesome:5.11.2"
@@ -34,8 +35,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude group: "org.junit.vintage", module: "junit-vintage-engine"
     }
-    testImplementation("org.optaplanner:optaplanner-test:${optaplannerVersion}")
-    testImplementation("org.optaplanner:optaplanner-benchmark:${optaplannerVersion}")
+    testImplementation("org.optaplanner:optaplanner-test")
+    testImplementation("org.optaplanner:optaplanner-benchmark")
 }
 
 test {

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -21,12 +21,12 @@ repositories {
 }
 
 dependencies {
-    // Alternatively, use "io.quarkus:quarkus-universe-bom" which includes both quarkus-bom and optaplanner-bom.
-    implementation enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}")
-    implementation "org.optaplanner:optaplanner-quarkus:${optaplannerVersion}"
-    implementation "org.optaplanner:optaplanner-quarkus-jackson:${optaplannerVersion}"
-    implementation "org.optaplanner:optaplanner-quarkus-benchmark:${optaplannerVersion}"
-    implementation "org.optaplanner:optaplanner-test:${optaplannerVersion}"
+    implementation enforcedPlatform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
+    implementation platform("io.quarkus:quarkus-bom:${quarkusVersion}")
+    implementation "org.optaplanner:optaplanner-quarkus"
+    implementation "org.optaplanner:optaplanner-quarkus-jackson"
+    implementation "org.optaplanner:optaplanner-quarkus-benchmark"
+    implementation "org.optaplanner:optaplanner-test"
     implementation "io.quarkus:quarkus-resteasy"
     implementation "io.quarkus:quarkus-resteasy-jackson"
     implementation "io.quarkus:quarkus-hibernate-orm-panache"

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-    implementation enforcedPlatform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation platform("io.quarkus:quarkus-bom:${quarkusVersion}")
+    implementation enforcedPlatform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation "org.optaplanner:optaplanner-quarkus"
     implementation "org.optaplanner:optaplanner-quarkus-jackson"
     implementation "org.optaplanner:optaplanner-quarkus-benchmark"


### PR DESCRIPTION
Suggestion to move to platform resolution of optaplanner-bom
If we decide to switch to the platform I will add another commit to update Spring and Quarkus example as well

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
