### PR TITLE
Fix VRP SolverResourceTest

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,7 @@ How to retest this PR or trigger a specific build:
 </summary>
 
 * for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
+* for a <b>full downstream build</b> please add the label `run_fdb`
 * for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
 * for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
 * for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -1,11 +1,11 @@
 
-name: Build Chain
+name: [FDB] Build Chain
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [labeled]
     branches:
-      - development
+      - main
       - 8.*
     paths-ignore:
       - 'LICENSE*'
@@ -17,8 +17,9 @@ on:
 
 jobs:
   build-chain:
+    if: contains(github.event.pull_request.labels.*.name, 'run_fdb')
     concurrency:
-      group: pull_request-${{ github.head_ref }}
+      group: fdb-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [labeled]
     branches:
-      - main
+      - development
       - 8.*
     paths-ignore:
       - 'LICENSE*'

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -73,6 +73,11 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- UI -->
     <dependency>


### PR DESCRIPTION
With the current termination configured in the test profile, solving
ends when the CH is done. This is too short for the test to be able to
reliably verify the solver is solving. So instead of that, just wait
until it stops solving.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
