### PR TITLE
Fix the quickstarts distribution after adding VRP

### DIFF
--- a/build/optaplanner-distribution/src/main/assembly/assembly-optaplanner-quickstarts.xml
+++ b/build/optaplanner-distribution/src/main/assembly/assembly-optaplanner-quickstarts.xml
@@ -83,7 +83,7 @@
     </fileSet>
     <fileSet>
       <directory>../../use-cases/vehicle-routing/target</directory>
-      <outputDirectory>binaries/use-cases/vehicle-routing</outputDirectory>
+      <outputDirectory>quickstarts/binaries/use-cases/vehicle-routing</outputDirectory>
       <includes>
         <include>quarkus-app/**</include>
       </includes>

--- a/build/optaplanner-distribution/src/main/assembly/sources.xml
+++ b/build/optaplanner-distribution/src/main/assembly/sources.xml
@@ -65,7 +65,7 @@
     <fileSet>
       <useDefaultExcludes>false</useDefaultExcludes>
       <directory>../../use-cases/vehicle-routing</directory>
-      <outputDirectory>sources/use-cases/vehicle-routing</outputDirectory>
+      <outputDirectory>quickstarts/sources/use-cases/vehicle-routing</outputDirectory>
       <excludes>
         <exclude>target/**</exclude>
         <exclude>.gitignore</exclude>


### PR DESCRIPTION
The new vehicle routing quickstart ends up in the wrong subdirectories in the distribution zip. This PR fixes the quickstarts assembly.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->
