### PR TITLE
Readme commands order picking (parallel PR that didn't apply here yet)

### DIFF
--- a/use-cases/order-picking/README.adoc
+++ b/use-cases/order-picking/README.adoc
@@ -1,6 +1,19 @@
 = Order picking (Java, Quarkus, Maven)
 
+Generate an optimal picking plan for completing a set of orders.
+
+image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/screenshot/quarkus-order-picking-screenshot.png[]
+
 == Run the application with live coding
+
+. Git clone the optaplanner-quickstarts repo:
++
+[source, shell]
+----
+$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+...
+$ cd optaplanner-quickstarts/use-cases/order-picking
+----
 
 . Start the application:
 +


### PR DESCRIPTION
Like the Ghostbusters, the beams got crossed. A parallel PR did this for the other quickstarts after the order picking quickstart was PR'ed. This aligns that.