### PR TITLE
Bump Quarkus version to 2.4.0.Final

### DIFF
--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,8 +11,7 @@
 
   <properties>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
 

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.2.2.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id "java"
-    id "io.quarkus" version"2.3.0.Final"
+    id "io.quarkus" version "2.4.0.Final"
 }
 
-def quarkusVersion ="2.3.0.Final"
 def optaplannerVersion = "8.13.0-SNAPSHOT"
+def quarkusVersion = "2.4.0.Final"
 
 group = "org.acme"
 version = "0.1.0-SNAPSHOT"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -10,10 +10,8 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.io.quarkus>2.3.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.13.0-SNAPSHOT</version.org.optaplanner>
-
+    <version.io.quarkus>2.4.0.Final</version.io.quarkus>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
   </properties>


### PR DESCRIPTION
(cherry picked from commit 7cac9eedfde57391aef159e55be0ed3739106030)

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
