### PR TITLE
PLANNER-2571 Add a workaround for a race condition

### DIFF
--- a/technology/java-spring-boot/src/test/java/org/acme/schooltimetabling/rest/TimeTableControllerTest.java
+++ b/technology/java-spring-boot/src/test/java/org/acme/schooltimetabling/rest/TimeTableControllerTest.java
@@ -47,7 +47,7 @@ public class TimeTableControllerTest {
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
             timeTable = timeTableController.getTimeTable();
-        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING);
+        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING || !timeTable.getScore().isFeasible());
 
         assertFalse(timeTable.getLessonList().isEmpty());
         for (Lesson lesson : timeTable.getLessonList()) {

--- a/technology/kotlin-quarkus/src/test/kotlin/org/acme/kotlin/schooltimetabling/rest/TimeTableResourceTest.kt
+++ b/technology/kotlin-quarkus/src/test/kotlin/org/acme/kotlin/schooltimetabling/rest/TimeTableResourceTest.kt
@@ -42,7 +42,7 @@ class TimeTableResourceTest {
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L)
             timeTable = timeTableResource.getTimeTable()
-        } while (timeTable.solverStatus != SolverStatus.NOT_SOLVING)
+        } while (timeTable.solverStatus != SolverStatus.NOT_SOLVING || !timeTable.score!!.isFeasible)
         Assertions.assertFalse(timeTable.lessonList.isEmpty())
         for (lesson in timeTable.lessonList) {
             Assertions.assertNotNull(lesson.timeslot)

--- a/use-cases/maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/rest/MaintenanceScheduleResourceTest.java
+++ b/use-cases/maintenance-scheduling/src/test/java/org/acme/maintenancescheduling/rest/MaintenanceScheduleResourceTest.java
@@ -41,7 +41,8 @@ public class MaintenanceScheduleResourceTest {
     public void solveDemoDataUntilFeasible() throws InterruptedException {
         maintenanceScheduleResource.solve();
         MaintenanceSchedule maintenanceSchedule = maintenanceScheduleResource.getSchedule();
-        while (maintenanceSchedule.getSolverStatus() != SolverStatus.NOT_SOLVING) {
+        while (maintenanceSchedule.getSolverStatus() != SolverStatus.NOT_SOLVING
+                || !maintenanceSchedule.getScore().isFeasible()) {
             // Quick polling (not a Test Thread Sleep anti-pattern)
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);

--- a/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
+++ b/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
@@ -46,7 +46,7 @@ public class TimeTableResourceTest {
             // Test is still fast on fast machines and doesn't randomly fail on slow machines.
             Thread.sleep(20L);
             timeTable = timeTableResource.getTimeTable();
-        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING);
+        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING || !timeTable.getScore().isFeasible());
 
         assertFalse(timeTable.getLessonList().isEmpty());
         for (Lesson lesson : timeTable.getLessonList()) {


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2571

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
