### PR TITLE
 PLANNER-2559 Use bootstrap margin, padding, badge and card classes + remove trim()

### DIFF
--- a/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/app.js
+++ b/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/app.js
@@ -94,7 +94,7 @@ function refreshTimeTable() {
 
     $.each(timeTable.lessonList, (index, lesson) => {
       const color = pickColor(lesson.subject);
-      const lessonElementWithoutDelete = $(`<div class="card lesson" style="background-color: ${color}"/>`)
+      const lessonElementWithoutDelete = $(`<div class="card" style="background-color: ${color}"/>`)
         .append($(`<div class="card-body p-2"/>`)
           .append($(`<h5 class="card-title mb-1"/>`).text(lesson.subject))
           .append($(`<p class="card-text ml-2 mb-1"/>`)

--- a/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/index.html
+++ b/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/index.html
@@ -35,7 +35,7 @@
     <h1>High school time table solver</h1>
     <p>Generate the optimal schedule for your teachers and students.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="refreshButton" type="button" class="btn btn-secondary">
             <span class="fas fa-refresh"></span> Refresh
         </button>
@@ -61,7 +61,7 @@
             </ul>
         </div>
     </div>
-    <div class="tab-content" id="myTabContent">
+    <div class="tab-content mb-4" id="myTabContent">
         <div class="tab-pane fade show active" id="byRoomPanel" role="tabpanel" aria-labelledby="byRoomTab">
             <table class="table table-borderless table-striped timeTableSolution" id="timeTableByRoom">
                 <!-- Filled in by app.js -->
@@ -79,7 +79,7 @@
         </div>
     </div>
 
-    <h2 style="margin-top: 2rem">Unassigned lessons</h2>
+    <h2>Unassigned lessons</h2>
     <div id="unassignedLessons" class="card-columns"></div>
 </div>
 

--- a/technology/java-activemq-quarkus/common/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/technology/java-activemq-quarkus/common/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -41,9 +41,9 @@ public class Lesson {
 
     public Lesson(Long id, String subject, String teacher, String studentGroup) {
         this.id = id;
-        this.subject = subject.trim();
-        this.teacher = teacher.trim();
-        this.studentGroup = studentGroup.trim();
+        this.subject = subject;
+        this.teacher = teacher;
+        this.studentGroup = studentGroup;
     }
 
     public Lesson(long id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {

--- a/technology/java-activemq-quarkus/common/src/main/java/org/acme/schooltimetabling/domain/Room.java
+++ b/technology/java-activemq-quarkus/common/src/main/java/org/acme/schooltimetabling/domain/Room.java
@@ -30,7 +30,7 @@ public class Room {
     }
 
     public Room(long id, String name) {
-        this.name = name.trim();
+        this.name = name;
         this.id = id;
     }
 

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -50,9 +50,9 @@ public class Lesson {
     }
 
     public Lesson(String subject, String teacher, String studentGroup) {
-        this.subject = subject.trim();
-        this.teacher = teacher.trim();
-        this.studentGroup = studentGroup.trim();
+        this.subject = subject;
+        this.teacher = teacher;
+        this.studentGroup = studentGroup;
     }
 
     public Lesson(long id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Room.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Room.java
@@ -36,7 +36,7 @@ public class Room {
     }
 
     public Room(String name) {
-        this.name = name.trim();
+        this.name = name;
     }
 
     public Room(long id, String name) {

--- a/technology/java-spring-boot/src/main/resources/static/app.js
+++ b/technology/java-spring-boot/src/main/resources/static/app.js
@@ -93,7 +93,7 @@ function refreshTimeTable() {
 
     $.each(timeTable.lessonList, (index, lesson) => {
       const color = pickColor(lesson.subject);
-      const lessonElementWithoutDelete = $(`<div class="card lesson" style="background-color: ${color}"/>`)
+      const lessonElementWithoutDelete = $(`<div class="card" style="background-color: ${color}"/>`)
         .append($(`<div class="card-body p-2"/>`)
           .append($(`<h5 class="card-title mb-1"/>`).text(lesson.subject))
           .append($(`<p class="card-text ml-2 mb-1"/>`)

--- a/technology/java-spring-boot/src/main/resources/static/index.html
+++ b/technology/java-spring-boot/src/main/resources/static/index.html
@@ -35,7 +35,7 @@
     <h1>High school time table solver</h1>
     <p>Generate the optimal schedule for your teachers and students.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="refreshButton" type="button" class="btn btn-secondary">
             <span class="fas fa-refresh"></span> Refresh
         </button>
@@ -79,7 +79,7 @@
             </table>
         </div>
     </div>
-    <div>
+    <div class="mb-4">
         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#lessonDialog">
             <span class="fas fa-plus"></span> Add lesson
         </button>
@@ -91,7 +91,7 @@
         </button>
     </div>
 
-    <h2 style="margin-top: 2rem">Unassigned lessons</h2>
+    <h2>Unassigned lessons</h2>
     <div id="unassignedLessons" class="card-columns"></div>
 </div>
 

--- a/technology/kotlin-quarkus/src/main/resources/META-INF/resources/app.js
+++ b/technology/kotlin-quarkus/src/main/resources/META-INF/resources/app.js
@@ -93,7 +93,7 @@ function refreshTimeTable() {
 
     $.each(timeTable.lessonList, (index, lesson) => {
       const color = pickColor(lesson.subject);
-      const lessonElementWithoutDelete = $(`<div class="card lesson" style="background-color: ${color}"/>`)
+      const lessonElementWithoutDelete = $(`<div class="card" style="background-color: ${color}"/>`)
         .append($(`<div class="card-body p-2"/>`)
           .append($(`<h5 class="card-title mb-1"/>`).text(lesson.subject))
           .append($(`<p class="card-text ml-2 mb-1"/>`)

--- a/technology/kotlin-quarkus/src/main/resources/META-INF/resources/index.html
+++ b/technology/kotlin-quarkus/src/main/resources/META-INF/resources/index.html
@@ -35,7 +35,7 @@
     <h1>High school time table solver</h1>
     <p>Generate the optimal schedule for your teachers and students.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="refreshButton" type="button" class="btn btn-secondary">
             <span class="fas fa-refresh"></span> Refresh
         </button>
@@ -78,7 +78,7 @@
             </table>
         </div>
     </div>
-    <div>
+    <div class="mb-4">
         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#lessonDialog">
             <span class="fas fa-plus"></span> Add lesson
         </button>
@@ -90,7 +90,7 @@
         </button>
     </div>
 
-    <h2 style="margin-top: 2rem">Unassigned lessons</h2>
+    <h2>Unassigned lessons</h2>
     <div id="unassignedLessons" class="card-columns"></div>
 </div>
 

--- a/use-cases/call-center/src/main/resources/META-INF/resources/index.html
+++ b/use-cases/call-center/src/main/resources/META-INF/resources/index.html
@@ -37,7 +37,7 @@
     <h1>Call center realtime scheduling</h1>
     <p>Assign incoming calls to agents based on required skills and minimize the customer waiting time.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="solveButton" type="button" class="btn btn-success">
             <span class="fas fa-play"></span> Solve
         </button>

--- a/use-cases/call-center/src/main/resources/META-INF/resources/style.css
+++ b/use-cases/call-center/src/main/resources/META-INF/resources/style.css
@@ -1,11 +1,3 @@
-.call-btn {
-  background-color: White;
-  border: 2px solid red;
-  color: Red;
-  padding: 4px 4px;
-  cursor: pointer;
-}
-
 .agent-row {
     border: 2px solid grey;
 }

--- a/use-cases/order-picking/src/main/resources/META-INF/resources/index.html
+++ b/use-cases/order-picking/src/main/resources/META-INF/resources/index.html
@@ -36,7 +36,7 @@
     <h1>Order Picking</h1>
     <p>Generate an optimal picking plan for completing a set of orders.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="refreshButton" type="button" class="btn btn-success">
             <span class="fas fa-sync"></span> Refresh
         </button>

--- a/use-cases/school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/use-cases/school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -50,9 +50,9 @@ public class Lesson {
     }
 
     public Lesson(String subject, String teacher, String studentGroup) {
-        this.subject = subject.trim();
-        this.teacher = teacher.trim();
-        this.studentGroup = studentGroup.trim();
+        this.subject = subject;
+        this.teacher = teacher;
+        this.studentGroup = studentGroup;
     }
 
     public Lesson(long id, String subject, String teacher, String studentGroup, Timeslot timeslot, Room room) {

--- a/use-cases/school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Room.java
+++ b/use-cases/school-timetabling/src/main/java/org/acme/schooltimetabling/domain/Room.java
@@ -37,7 +37,7 @@ public class Room {
     }
 
     public Room(String name) {
-        this.name = name.trim();
+        this.name = name;
     }
 
     public Room(long id, String name) {

--- a/use-cases/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -140,7 +140,7 @@ function refreshTimeTable() {
 
     $.each(timeTable.lessonList, (index, lesson) => {
       const color = pickColor(lesson.subject);
-      const lessonElementWithoutDelete = $(`<div class="card lesson" style="background-color: ${color}"/>`)
+      const lessonElementWithoutDelete = $(`<div class="card" style="background-color: ${color}"/>`)
         .append($(`<div class="card-body p-2"/>`)
           .append($(`<h5 class="card-title mb-1"/>`).text(lesson.subject))
           .append($(`<p class="card-text ml-2 mb-1"/>`)

--- a/use-cases/school-timetabling/src/main/resources/META-INF/resources/index.html
+++ b/use-cases/school-timetabling/src/main/resources/META-INF/resources/index.html
@@ -35,7 +35,7 @@
     <h1>High school time table solver</h1>
     <p>Generate the optimal schedule for your teachers and students.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="refreshButton" type="button" class="btn btn-secondary">
             <span class="fas fa-refresh"></span> Refresh
         </button>
@@ -78,7 +78,7 @@
             </table>
         </div>
     </div>
-    <div>
+    <div class="mb-4">
         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#lessonDialog">
             <span class="fas fa-plus"></span> Add lesson
         </button>
@@ -90,7 +90,7 @@
         </button>
     </div>
 
-    <h2 style="margin-top: 2rem">Unassigned lessons</h2>
+    <h2>Unassigned lessons</h2>
     <div id="unassignedLessons" class="card-columns"></div>
 </div>
 

--- a/use-cases/vaccination-scheduling/src/main/resources/META-INF/resources/index.html
+++ b/use-cases/vaccination-scheduling/src/main/resources/META-INF/resources/index.html
@@ -20,7 +20,7 @@
     <h1>Vaccination scheduler</h1>
     <p>Generate the optimal schedule to inject a country with COVID-19 vaccines.</p>
 
-    <div style="margin-bottom: .5rem">
+    <div class="mb-2">
         <button id="refreshButton" type="button" class="btn btn-secondary">
             <span class="fas fa-refresh"></span> Refresh
         </button>
@@ -60,9 +60,9 @@
             <div id="leafletMap" style="width: 100%; height: 850px;"></div>
         </div>
         <div class="tab-pane fade" id="unassignedTabDiv" role="tabpanel" aria-labelledby="unassignedTab">
-            <p>There are <span id="assignedPersonCount">0</span> assigned persons
+            <p class="mb-4">There are <span id="assignedPersonCount">0</span> assigned persons
                 and <span id="unassignedPersonCount">0</span> unassigned persons.</p>
-            <h2 style="margin-top: 2rem">Unassigned persons</h2>
+            <h2>Unassigned persons</h2>
             <div id="unassignedPersons" class="card-columns"></div>
         </div>
     </div>


### PR DESCRIPTION
@rsynek I hope your fine with these changes, they went much further than originally intended on the call center use case. The goal was to standardize the use of bootstrap.

BEFORE

![Selection_923](https://user-images.githubusercontent.com/176880/141798039-f08d3097-6b23-4cb8-a9e6-6a67a7962bd5.png)

AFTER

![Selection_922](https://user-images.githubusercontent.com/176880/141797886-c88bef98-c117-4969-b01d-38b11549efba.png)

