### PR TITLE
Fix activemq readme instructions

### DIFF
--- a/technology/java-activemq-quarkus/README.adoc
+++ b/technology/java-activemq-quarkus/README.adoc
@@ -69,7 +69,7 @@ $ mvn package -DskipTests
 +
 [source, shell]
 ----
-$ java -jar ./target/*-runner.jar -Dquarkus.http.port=8081
+$ java -Dquarkus.http.port=8081 -jar ./target/quarkus-app/quarkus-run.jar
 ----
 
 [NOTE]
@@ -89,7 +89,7 @@ $ mvn package -DskipTests
 +
 [source, shell]
 ----
-$ java -jar ./target/*-runner.jar
+$ java -jar ./target/quarkus-app/quarkus-run.jar
 ----
 +
 
@@ -113,7 +113,7 @@ $ mvn package -Dnative -DskipTests -Dquarkus.profile=native
 +
 [source, shell]
 ----
-$ ./target/*-runner
+$ ./target/*-runner -Dquarkus.http.port=8081
 ----
 
 === Compile and run the Client application natively


### PR DESCRIPTION
Thanks @dupliaka for finding and reporting!

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
