### PR TITLE
PLANNER-2581 improve error message of the run.sh

### DIFF
--- a/technology/java-activemq-quarkus/run.sh
+++ b/technology/java-activemq-quarkus/run.sh
@@ -48,6 +48,12 @@ if [ ! -d target ]; then
   mkdir target
 fi
 
+# Check if docker-compose is available.
+if ! docker-compose --version &> /dev/null ; then
+  echo "docker-compose was not detected. Please make sure that docker-compose has been properly installed."
+  exit 1
+fi
+
 # Run docker-compose to start ActiveMQ broker.
 docker-compose up > target/activemq.log 2>&1 &
 readonly PID_DOCKER_AMQ=$!
@@ -68,4 +74,12 @@ readonly URL="http://localhost:8080"
 wait_for_url "$URL" 60
 echo "Application available at $URL"
 echo "Press [Ctrl+C] to exit."
+
+echo
+if [ "$1" = "-v" ]; then
+  echo "--------------- SOLVER output ---------------"
+  tail -f target/solver.log
+else
+  echo "To display output of the solver, invoke this script with the '-v' option. Complete logs are available in the 'target' directory."
+fi
 wait


### PR DESCRIPTION
A couple of updates to the `run.sh` script to make it more user-friendly.
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2581

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
