### PR TITLE
[1.15.x] Bump Quarkus version to 2.6.0.final

### DIFF
--- a/technology/java-activemq-quarkus/client/src/test/java/org/acme/schooltimetabling/ActiveMQTestResourceLifecycleManager.java
+++ b/technology/java-activemq-quarkus/client/src/test/java/org/acme/schooltimetabling/ActiveMQTestResourceLifecycleManager.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
 
 public class ActiveMQTestResourceLifecycleManager implements QuarkusTestResourceLifecycleManager {
 

--- a/technology/java-activemq-quarkus/client/src/test/java/org/acme/schooltimetabling/TimeTableResourceTest.java
+++ b/technology/java-activemq-quarkus/client/src/test/java/org/acme/schooltimetabling/TimeTableResourceTest.java
@@ -47,9 +47,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
-import io.smallrye.reactive.messaging.connectors.InMemorySink;
-import io.smallrye.reactive.messaging.connectors.InMemorySource;
+import io.smallrye.reactive.messaging.providers.connectors.InMemoryConnector;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySink;
+import io.smallrye.reactive.messaging.providers.connectors.InMemorySource;
 
 @QuarkusTest
 @QuarkusTestResource(ActiveMQTestResourceLifecycleManager.class)

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -10,6 +10,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <version.org.apache.activemq>2.19.0</version.org.apache.activemq>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
     <version.io.quarkus>2.6.0.Final</version.io.quarkus>
 
@@ -47,6 +48,16 @@
         <groupId>org.acme</groupId>
         <artifactId>optaplanner-activemq-quarkus-school-timetabling-common</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>artemis-amqp-protocol</artifactId>
+        <version>${version.org.apache.activemq}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>artemis-server</artifactId>
+        <version>${version.org.apache.activemq}</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.6.0.CR1"
+    id "io.quarkus" version "2.6.0.Final"
 }
 
-def quarkusVersion = "2.6.0.CR1"
+def quarkusVersion = "2.6.0.Final"
 def optaplannerVersion = "8.15.0-SNAPSHOT"
 
 group = "org.acme"

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.5.1.Final"
+    id "io.quarkus" version "2.6.0.CR1"
 }
 
-def quarkusVersion = "2.5.1.Final"
+def quarkusVersion = "2.6.0.CR1"
 def optaplannerVersion = "8.15.0-SNAPSHOT"
 
 group = "org.acme"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.5.1.Final</version.io.quarkus>
+    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.6.0.CR1</version.io.quarkus>
+    <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.15.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/optaplanner-quickstarts/pull/242

PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1799
- https://github.com/kiegroup/optaplanner/pull/1730
- https://github.com/kiegroup/kogito-apps/pull/1167
- https://github.com/kiegroup/kogito-examples/pull/1043
- https://github.com/kiegroup/optaplanner-quickstarts/pull/246