### PR TITLE
Split nightly jobs

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -1,8 +1,11 @@
+import org.kie.jenkins.jobdsl.model.Folder
 import org.kie.jenkins.jobdsl.templates.KogitoJobTemplate
 import org.kie.jenkins.jobdsl.KogitoJobUtils
 
-def getDefaultJobParams(String repoName = 'optaplanner-quickstarts') {
-    return KogitoJobTemplate.getDefaultJobParams(this, repoName)
+OPTAPLANNER_QUICKSTARTS = 'optaplanner-quickstarts'
+
+def getDefaultJobParams(String repoName = OPTAPLANNER_QUICKSTARTS) {
+    return KogitoJobUtils.getDefaultJobParams(this, repoName)
 }
 
 Map getMultijobPRConfig() {
@@ -11,7 +14,7 @@ Map getMultijobPRConfig() {
         buildchain: true,
         jobs : [
             [
-                id: 'optaplanner-quickstarts',
+                id: OPTAPLANNER_QUICKSTARTS,
                 primary: true,
                 env : [
                     // Sonarcloud analysis only on main branch
@@ -27,31 +30,16 @@ Map getMultijobPRConfig() {
     ]
 }
 
-// Optaplanner PR checks
-setupMultijobPrDefaultChecks()
-setupMultijobPrNativeChecks()
-setupMultijobPrLTSChecks()
+// PR checks
+KogitoJobUtils.createAllEnvsPerRepoPRJobs(this, { jobFolder -> getMultijobPRConfig() }, { return getDefaultJobParams() })
+
+// Create all Nightly jobs
+KogitoJobUtils.createAllJobsForArtifactsRepository(this, 'kogito-runtimes', ['optaplanner'])
 
 // Tools
-KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'optaplanner-quickstarts', 'OptaPlanner Quickstarts', [
+KogitoJobUtils.createQuarkusUpdateToolsJob(this, OPTAPLANNER_QUICKSTARTS, [
     properties: [ 'version.io.quarkus' ],
 ], [
     // Escaping quotes so it is correctly handled by Json marshalling/unmarshalling
     regex: [ 'id \\"io.quarkus\\" version', 'def quarkusVersion =' ]
 ])
-
-/////////////////////////////////////////////////////////////////
-// Methods
-/////////////////////////////////////////////////////////////////
-
-void setupMultijobPrDefaultChecks() {
-    KogitoJobTemplate.createMultijobPRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
-}
-
-void setupMultijobPrNativeChecks() {
-    KogitoJobTemplate.createMultijobNativePRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
-}
-
-void setupMultijobPrLTSChecks() {
-    KogitoJobTemplate.createMultijobLTSPRJobs(this, getMultijobPRConfig()) { return getDefaultJobParams() }
-}

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,20 +1,8 @@
 #!/bin/bash -e
 
-TEMP_DIR=`mktemp -d`
-
-branch=$1
-author=$2
-
-if [ -z $branch ]; then
-  branch='main'
-fi
-
-if [ -z $author ]; then
-  author='kiegroup'
-fi
-
-echo "----- Cloning pipelines repo from ${author} on branch ${branch}"
-git clone --single-branch --branch ${branch} https://github.com/${author}/kogito-pipelines.git $TEMP_DIR
-
-echo '----- Launching seed tests'
-${TEMP_DIR}/dsl/seed/scripts/seed_test.sh ${TEMP_DIR}
+file=$(mktemp)
+# For more usage of the script, use ./test.sh -h
+# TODO to update before merge
+curl -o ${file} https://raw.githubusercontent.com/radtriste/kogito-pipelines/split_nightly_jobs/dsl/seed/scripts/seed_test.sh
+chmod u+x ${file}
+${file} $@

--- a/.ci/jenkins/scripts/update_version/after_main.groovy
+++ b/.ci/jenkins/scripts/update_version/after_main.groovy
@@ -1,0 +1,16 @@
+void execute(def pipelinesCommon) {
+    if (pipelinesCommon.isRelease()) {
+        assert !sh (script:
+                'grep -Rn "SNAPSHOT" --include={pom.xml,build.gradle} | ' +
+                'grep -v -e "0.1.0-SNAPSHOT" -e ">1.0-SNAPSHOT" | ' +
+                'cat', returnStdout: true)
+    }
+    if (pipelinesCommon.isCreatePr()) {
+        assert !sh (script:
+                'grep -Rn "SNAPSHOT" --include={pom.xml,build.gradle} | ' +
+                'grep -v -e "${getProjectVersion()}" | ' +
+                'cat', returnStdout: true)
+    }
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/git_stage_files.groovy
+++ b/.ci/jenkins/scripts/update_version/git_stage_files.groovy
@@ -1,0 +1,6 @@
+void execute(def pipelinesCommon) {
+    githubscm.findAndStageNotIgnoredFiles('pom.xml')
+    githubscm.findAndStageNotIgnoredFiles('build.gradle')
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/init.groovy
+++ b/.ci/jenkins/scripts/update_version/init.groovy
@@ -1,0 +1,14 @@
+void execute(def pipelinesCommon) {
+    echo 'Hello from init script'
+    if (pipelinesCommon.isRelease() || pipelinesCommon.isCreatePR()) {
+        // Verify version is set
+        assert pipelinesCommon.getOptaPlannerVersion()
+
+        if (pipelinesCommon.isRelease()) {
+            // Verify if on right release branch
+            assert pipelinesCommon.getGitBranch() == util.getReleaseBranchFromVersion(pipelinesCommon.getOptaPlannerVersion())
+        }
+    }
+}
+
+return this

--- a/.ci/jenkins/scripts/update_version/main.groovy
+++ b/.ci/jenkins/scripts/update_version/main.groovy
@@ -1,0 +1,12 @@
+void execute(def pipelinesCommon) {
+    maven.mvnSetVersionProperty(pipelinesCommon.getDefaultMavenCommand(), 'version.org.optaplanner', pipelinesCommon.getOptaPlannerVersion())
+    maven.mvnVersionsUpdateParentAndChildModules(pipelinesCommon.getDefaultMavenCommand(), pipelinesCommon.getOptaPlannerVersion(), !pipelinesCommon.isRelease())
+    
+    gradleVersionsUpdate(pipelinesCommon.getOptaPlannerVersion())
+}
+
+void gradleVersionsUpdate(String newVersion) {
+    sh "find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${newVersion}\"/' {} \\;"
+}
+
+return this

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Jenkins Tests
+
+on:
+  pull_request:
+    paths:
+      - '.ci/jenkins/**'
+
+jobs:
+  dsl-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout 
+      uses: actions/checkout@v2
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Test DSL
+      run: cd .ci/jenkins/dsl && ./test.sh -b ${{ github.head_ref }} -o ${{ github.event.pull_request.user.login }} -t ${{ github.base_ref }} -a ${{ github.event.pull_request.base.user.login }}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
