### PR TITLE
nightly GHA job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,56 @@
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    concurrency:
+      group: nightly
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-version: [11]
+      fail-fast: true
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
+    steps:
+      - name: Support long paths
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: kiegroup/kogito-pipelines/.ci/actions/long-paths@main
+      - name: Java and Maven Setup
+        uses: kiegroup/kogito-pipelines/.ci/actions/maven@main
+        with:
+          java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+      - uses: actions/checkout@v2      
+      - name: Build with Maven
+        run: mvn -B clean install --file pom.xml dependency:tree -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
+      - name: Set build information
+        if: ${{ always() }}
+        run: |
+          echo "project_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "project_name=${{github.repository}}" >> $GITHUB_ENV
+          echo "action_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+      - name: Set failure message
+        if: ${{ failure() }}
+        run: echo "zulip_message=:cross_mark:Build ERROR. See ${{env.action_url}}" >> $GITHUB_ENV  
+      - name: Set success message
+        if: ${{ success() }}
+        run: echo "zulip_message=:check:Build OK. See ${{env.action_url}}" >> $GITHUB_ENV  
+      - name: Send a stream message
+        if: ${{ always() }}
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: ${{ secrets.ZULIP_EMAIL }}
+          organization-url: 'https://kie.zulipchat.com'
+          to: 'optaplanner-dev'
+          type: 'stream'
+          topic: 'status of ${{env.project_name}} - ${{env.project_branch}}'
+          content: ${{ env.zulip_message }}


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLANNER-2604

Can you please guys fill the gaps? from `Set failure message`, `Set success message` and `Send a stream message` steps?

Once we have it clear I will create `ZULIP_API_KEY` secret before merging.
I set two different event types:

- `schedule` to be run based on cron expression `0 0 * * *` (every night)(for default branch, stable in this case)
- `workflow_dispatch` to manually run it (choosing the branch)

You can check execution tests here https://github.com/Ginxo/optaplanner-quickstarts/actions/workflows/nightly.yml

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
