### PR TITLE
Gradle: Fix hello world testing with JUnit5

### DIFF
--- a/hello-world/build.gradle
+++ b/hello-world/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 def optaplannerVersion = "8.17.0-SNAPSHOT"
 def logbackVersion = "1.2.9"
+def junitJupiterVersion = "5.8.2"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"
@@ -24,6 +25,7 @@ dependencies {
     implementation platform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation "org.optaplanner:optaplanner-core"
     testImplementation "org.optaplanner:optaplanner-test"
+    testImplementation "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 
     runtimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 }
@@ -51,4 +53,6 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
+
+    useJUnitPlatform()
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

Fix `hello-world` gradle test to actually run tests and not just compile
- Ref: https://docs.gradle.org/current/userguide/java_testing.html#using_junit5
- Tested by running `gradle test` and breaking tests

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
