### PR TITLE
PLANNER-2648: Remove workaround for https://github.com/quarkusio/quarkus/issues/13341

### DIFF
--- a/technology/java-activemq-quarkus/README.adoc
+++ b/technology/java-activemq-quarkus/README.adoc
@@ -108,7 +108,7 @@ First, https://quarkus.io/guides/building-native-image#configuring-graalvm[insta
 [source, shell]
 ----
 $ cd solver
-$ mvn package -Dnative -DskipTests -Dquarkus.profile=native
+$ mvn package -Dnative -DskipTests
 ----
 +
 . Run the native executable:

--- a/technology/kotlin-quarkus/README.adoc
+++ b/technology/kotlin-quarkus/README.adoc
@@ -71,13 +71,8 @@ To run it on port 8081 instead, add `-Dquarkus.http.port=8081`.
 +
 [source, shell]
 ----
-$ mvn package -Dnative -DskipTests    -Dquarkus.profile=native
+$ mvn package -Dnative -DskipTests
 ----
-+
-[WARNING]
-====
-The `-Dquarkus.profile=native` is a temporary workaround for https://github.com/quarkusio/quarkus/issues/13341[an issue in Quarkus 1.10].
-====
 
 . Run a database. By default, `application.properties` is configured for H2:
 .. Download the http://www.h2database.com/html/download.html[H2 database] (Platform-independent zip) and unzip it.

--- a/technology/kotlin-quarkus/src/main/docker/Dockerfile.native
+++ b/technology/kotlin-quarkus/src/main/docker/Dockerfile.native
@@ -3,7 +3,7 @@
 #
 # Before building the container image run:
 #
-# mvn package -Pnative -Dquarkus.native.container-build=true -Dquarkus.profile=native
+# mvn package -Pnative -Dquarkus.native.container-build=true
 #
 # Then, build the image with:
 #

--- a/use-cases/employee-scheduling/README.adoc
+++ b/use-cases/employee-scheduling/README.adoc
@@ -67,13 +67,8 @@ To run it on port 8081 instead, add `-Dquarkus.http.port=8081`.
 +
 [source, shell]
 ----
-$ mvn package -Dnative -DskipTests    -Dquarkus.profile=native
+$ mvn package -Dnative -DskipTests
 ----
-+
-[WARNING]
-====
-The `-Dquarkus.profile=native` is a temporary workaround for https://github.com/quarkusio/quarkus/issues/13341[an issue in Quarkus 1.10].
-====
 
 . Run a database. By default, `application.properties` is configured for H2:
 .. Download the http://www.h2database.com/html/download.html[H2 database] (Platform-independent zip) and unzip it.

--- a/use-cases/employee-scheduling/src/main/docker/Dockerfile.native
+++ b/use-cases/employee-scheduling/src/main/docker/Dockerfile.native
@@ -3,7 +3,7 @@
 #
 # Before building the docker image run:
 #
-# mvn package -Pnative -Dquarkus.native.container-build=true -Dquarkus.profile=native
+# mvn package -Pnative -Dquarkus.native.container-build=true
 #
 # Then, build the image with:
 #

--- a/use-cases/maintenance-scheduling/README.adoc
+++ b/use-cases/maintenance-scheduling/README.adoc
@@ -67,13 +67,8 @@ To run it on port 8081 instead, add `-Dquarkus.http.port=8081`.
 +
 [source, shell]
 ----
-$ mvn package -Dnative -DskipTests    -Dquarkus.profile=native
+$ mvn package -Dnative -DskipTests
 ----
-+
-[WARNING]
-====
-The `-Dquarkus.profile=native` is a temporary workaround for https://github.com/quarkusio/quarkus/issues/13341[an issue in Quarkus 1.10].
-====
 
 . Run a database. By default, `application.properties` is configured for H2:
 .. Download the http://www.h2database.com/html/download.html[H2 database] (Platform-independent zip) and unzip it.

--- a/use-cases/maintenance-scheduling/src/main/docker/Dockerfile.native
+++ b/use-cases/maintenance-scheduling/src/main/docker/Dockerfile.native
@@ -3,7 +3,7 @@
 #
 # Before building the docker image run:
 #
-# mvn package -Pnative -Dquarkus.native.container-build=true -Dquarkus.profile=native
+# mvn package -Pnative -Dquarkus.native.container-build=true
 #
 # Then, build the image with:
 #

--- a/use-cases/school-timetabling/README.adoc
+++ b/use-cases/school-timetabling/README.adoc
@@ -80,13 +80,8 @@ To run it on port 8081 instead, add `-Dquarkus.http.port=8081`.
 +
 [source, shell]
 ----
-$ mvn package -Dnative -DskipTests    -Dquarkus.profile=native
+$ mvn package -Dnative -DskipTests
 ----
-+
-[WARNING]
-====
-The `-Dquarkus.profile=native` is a temporary workaround for https://github.com/quarkusio/quarkus/issues/13341[an issue in Quarkus 1.10].
-====
 
 . Run a database. By default, `application.properties` is configured for H2:
 .. Download the http://www.h2database.com/html/download.html[H2 database] (Platform-independent zip) and unzip it.


### PR DESCRIPTION
`mvn package -Dnative -DskipTests` compiles successfully to a native executable, and uses the correct JDBC URL to connect to a remote H2 database.

Several use-cases already did not have the workaround, hence why they don't appear in the change list.
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2648

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
