### PR TITLE
KOGITO-6682 Force maven version to 3.8.1+

### DIFF
--- a/build/.mvn/wrapper/maven-wrapper.properties
+++ b/build/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6682

Related PRs:
- https://github.com/kiegroup/drools/pull/4174
- https://github.com/kiegroup/kogito-runtimes/pull/1962
- https://github.com/kiegroup/optaplanner/pull/1820
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/647
- https://github.com/kiegroup/optaplanner-quickstarts/pull/277
- https://github.com/kiegroup/kogito-apps/pull/1227
- https://github.com/kiegroup/kogito-examples/pull/1109