### PR TITLE
[8.11.x] Parametrize groupId of Quarkus maven plugin

### DIFF
--- a/technology/java-activemq-quarkus/client/pom.xml
+++ b/technology/java-activemq-quarkus/client/pom.xml
@@ -99,7 +99,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -90,7 +90,7 @@
           <version>${compiler-plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>io.quarkus</groupId>
+          <groupId>${quarkus.platform.group-id}</groupId>
           <artifactId>quarkus-maven-plugin</artifactId>
           <version>${quarkus.platform.version}</version>
           <executions>

--- a/technology/java-activemq-quarkus/solver/pom.xml
+++ b/technology/java-activemq-quarkus/solver/pom.xml
@@ -87,7 +87,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
       </plugin>
     </plugins>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -152,7 +152,7 @@
     <testSourceDirectory>src/test/kotlin</testSourceDirectory>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <executions>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -119,7 +119,7 @@
         <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <executions>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -108,7 +108,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <executions>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -136,7 +136,7 @@
         <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <executions>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -139,7 +139,7 @@
         <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <executions>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -123,7 +123,7 @@
         <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
+        <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>
         <executions>


### PR DESCRIPTION
A leftover from https://github.com/kiegroup/optaplanner-quickstarts/pull/273. The Quarkus maven plugin has a different groupId under the platform, too.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
