### PR TITLE
Add 10 hours between shifts constraints to employee scheduling

### DIFF
--- a/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
+++ b/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProvider.java
@@ -2,7 +2,6 @@ package org.acme.employeescheduling.solver;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 
 import org.acme.employeescheduling.domain.Availability;
 import org.acme.employeescheduling.domain.AvailabilityType;
@@ -61,9 +60,9 @@ public class EmployeeSchedulingConstraintProvider implements ConstraintProvider 
         return constraintFactory.forEachUniquePair(Shift.class,
                                                    Joiners.equal(Shift::getEmployee),
                                                    Joiners.lessThanOrEqual(Shift::getEnd, Shift::getStart))
-                .filter((firstShift, secondShift) -> firstShift.getEnd().until(secondShift.getStart(), ChronoUnit.HOURS) < 10)
+                .filter((firstShift, secondShift) -> Duration.between(firstShift.getEnd(), secondShift.getStart()).toHours() < 10)
                 .penalize("At least 10 hours between 2 shifts", HardSoftScore.ONE_HARD, (firstShift, secondShift) -> {
-                              int breakLength = (int) firstShift.getEnd().until(secondShift.getStart(), ChronoUnit.MINUTES);
+                              int breakLength = (int) Duration.between(firstShift.getEnd(), secondShift.getStart()).toMinutes();
                               return (10 * 60) - breakLength;
                           });
     }

--- a/use-cases/employee-scheduling/src/test/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProviderTest.java
+++ b/use-cases/employee-scheduling/src/test/java/org/acme/employeescheduling/solver/EmployeeSchedulingConstraintProviderTest.java
@@ -116,6 +116,37 @@ public class EmployeeSchedulingConstraintProviderTest {
     }
 
     @Test
+    public void testAtLeast10HoursBetweenConsecutiveShifts() {
+        Employee employee1 = new Employee("Amy", Set.of("Skill"));
+        Employee employee2 = new Employee("Beth", Set.of("Skill"));
+        constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::atLeast10HoursBetweenTwoShifts)
+                .given(employee1,
+                       new Shift(1L, DAY_START_TIME, DAY_END_TIME, "Location", "Skill", employee1),
+                       new Shift(2L, AFTERNOON_END_TIME, DAY_START_TIME.plusDays(1), "Location 2", "Skill", employee1))
+                .penalizesBy(360);
+        constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::atLeast10HoursBetweenTwoShifts)
+                .given(employee1,
+                       new Shift(1L, DAY_START_TIME, DAY_END_TIME, "Location", "Skill", employee1),
+                       new Shift(2L, DAY_END_TIME, DAY_START_TIME.plusDays(1), "Location 2", "Skill", employee1))
+                .penalizesBy(600);
+        constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::atLeast10HoursBetweenTwoShifts)
+                .given(employee1,
+                       new Shift(1L, DAY_START_TIME, DAY_END_TIME, "Location", "Skill", employee1),
+                       new Shift(2L, DAY_END_TIME.plusHours(10), DAY_START_TIME.plusDays(1), "Location 2", "Skill", employee1))
+                .penalizes(0);
+        constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::atLeast10HoursBetweenTwoShifts)
+                .given(employee1,
+                       new Shift(1L, DAY_START_TIME, DAY_END_TIME, "Location", "Skill", employee1),
+                       new Shift(2L, AFTERNOON_END_TIME, DAY_START_TIME.plusDays(1), "Location 2", "Skill", employee2))
+                .penalizes(0);
+        constraintVerifier.verifyThat(EmployeeSchedulingConstraintProvider::noOverlappingShifts)
+                .given(employee1,
+                       new Shift(1L, DAY_START_TIME, DAY_END_TIME, "Location", "Skill", employee1),
+                       new Shift(2L, DAY_START_TIME.plusDays(1), DAY_END_TIME.plusDays(1), "Location 2", "Skill", employee1))
+                .penalizes(0);
+    }
+
+    @Test
     public void testUnavailableEmployee() {
         Employee employee1 = new Employee("Amy", Set.of("Skill"));
         Employee employee2 = new Employee("Beth", Set.of("Skill"));


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
