### PR TITLE
PLANNER-2629 Pause best solution consumer

### DIFF
--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/LessonRepository.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/LessonRepository.java
@@ -21,7 +21,11 @@ import java.util.List;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import org.acme.schooltimetabling.domain.Lesson;
+import org.springframework.data.rest.core.annotation.RestResource;
+import org.springframework.transaction.annotation.Transactional;
 
+@RestResource(exported = false)
+@Transactional
 public interface LessonRepository extends PagingAndSortingRepository<Lesson, Long> {
 
     @Override

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/ProblemChangedRepositoryEventListener.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/ProblemChangedRepositoryEventListener.java
@@ -57,13 +57,6 @@ public class ProblemChangedRepositoryEventListener {
         assertNotSolving();
     }
 
-    @HandleBeforeCreate
-    @HandleBeforeSave
-    @HandleBeforeDelete
-    private void lessonCreateSaveDelete(Lesson lesson) {
-        assertNotSolving();
-    }
-
     public void assertNotSolving() {
         // TODO Race condition: if a timeTableSolverService.solve() call arrives concurrently,
         // the solver might start before the CRUD transaction completes. That's not very harmful, though.

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/TimeTableRepository.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/TimeTableRepository.java
@@ -16,6 +16,8 @@
 
 package org.acme.schooltimetabling.persistence;
 
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,9 +52,20 @@ public class TimeTableRepository {
     }
 
     public void save(TimeTable timeTable) {
+        try {
+            Thread.sleep(1000L);
+        } catch (InterruptedException ex) {
+            // nothing
+        }
         for (Lesson lesson : timeTable.getLessonList()) {
             // TODO this is awfully naive: optimistic locking causes issues if called by the SolverManager
             lessonRepository.save(lesson);
+
+//            Optional<Lesson> attachedLesson = lessonRepository.findById(lesson.getId());
+//            if (attachedLesson.isPresent()) {
+//                attachedLesson.get().setTimeslot(lesson.getTimeslot());
+//                attachedLesson.get().setRoom(lesson.getRoom());
+//            }
         }
     }
 

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/rest/LessonController.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/rest/LessonController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.acme.schooltimetabling.rest;
+
+import java.util.List;
+
+import org.acme.schooltimetabling.domain.Lesson;
+import org.acme.schooltimetabling.domain.TimeTable;
+import org.acme.schooltimetabling.persistence.LessonRepository;
+import org.acme.schooltimetabling.persistence.TimeTableRepository;
+import org.optaplanner.core.api.solver.ConsumptionPause;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/lessons")
+public class LessonController {
+
+    @Autowired
+    LessonRepository lessonRepository;
+
+    @Autowired
+    TimeTableRepository timeTableRepository;
+
+    @Autowired
+    SolverManager<TimeTable, Long> solverManager;
+
+    @GetMapping
+    public List<Lesson> getAll() {
+        return lessonRepository.findAll();
+    }
+
+    @PostMapping
+    public Lesson add(@RequestBody Lesson lesson) {
+        try (ConsumptionPause pause = solverManager.pauseBestSolutionConsumer(TimeTableRepository.SINGLETON_TIME_TABLE_ID)) {
+            lessonRepository.save(lesson);
+            solverManager.reloadProblem(TimeTableRepository.SINGLETON_TIME_TABLE_ID, timeTableRepository::findById);
+        }
+        return lesson;
+    }
+
+    @DeleteMapping("{id}")
+    public void delete(@PathVariable("id") Long id) {
+        try (ConsumptionPause pause = solverManager.pauseBestSolutionConsumer(TimeTableRepository.SINGLETON_TIME_TABLE_ID)) {
+            lessonRepository.deleteById(id);
+            solverManager.reloadProblem(TimeTableRepository.SINGLETON_TIME_TABLE_ID, timeTableRepository::findById);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2629
https://issues.redhat.com/browse/PLANNER-2650

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1832

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
