### PR TITLE
PLANNER-2657: Add native OpenShift Configuration for school timetabling

### DIFF
--- a/use-cases/school-timetabling/README.adoc
+++ b/use-cases/school-timetabling/README.adoc
@@ -127,7 +127,7 @@ To deploy the application on OpenShift using the native build:
 +
 [source, shell]
 ----
-$ mvn clean package -DskipTests -Dopenshift -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
 ----
 +
 . When the command is finished, you should see two pods in the Topology view: one for the _ephemeral_ Postgres database (data will not be saved), and one for the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:

--- a/use-cases/school-timetabling/README.adoc
+++ b/use-cases/school-timetabling/README.adoc
@@ -109,6 +109,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/school-timetabling` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see two pods in the Topology view: one for the _ephemeral_ Postgres database (data will not be saved), and one for the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -193,7 +193,7 @@
       </properties>
     </profile>
     <profile>
-      <id>openshift</id>
+      <id>openshift</id> <!-- Optional for use in OpenShift. -->
       <activation>
         <property>
           <name>openshift</name>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -192,6 +192,28 @@
         <quarkus.profile>native</quarkus.profile>
       </properties>
     </profile>
+    <profile>
+      <id>openshift</id>
+      <activation>
+        <property>
+          <name>openshift</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -193,15 +193,15 @@
       </properties>
     </profile>
     <profile>
-      <id>openshift</id> <!-- Optional for use in OpenShift. -->
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
       <activation>
         <property>
-          <name>openshift</name>
+          <name>openshift-native</name>
         </property>
       </activation>
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
-        <quarkus.profile>openshift</quarkus.profile>
+        <quarkus.profile>openshift-native</quarkus.profile>
       </properties>
       <dependencies>
         <dependency>

--- a/use-cases/school-timetabling/src/main/kubernetes/openshift.yml
+++ b/use-cases/school-timetabling/src/main/kubernetes/openshift.yml
@@ -1,0 +1,142 @@
+apiVersion: v1
+items:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      annotations:
+        template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+        template.openshift.io/expose-password: '{.data[''database-password'']}'
+        template.openshift.io/expose-username: '{.data[''database-user'']}'
+      labels:
+        app: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/instance: postgresql
+        template: postgresql-ephemeral-template
+      name: postgresql
+    stringData:
+      database-name: app
+      database-password: app
+      database-user: app
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        openshift.io/generated-by: OpenShiftNewApp
+        template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+      labels:
+        app: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/instance: postgresql
+        template: postgresql-ephemeral-template
+      name: postgresql
+    spec:
+      ports:
+        - name: postgresql
+          port: 5432
+          protocol: TCP
+          targetPort: 5432
+      selector:
+        name: postgresql
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        openshift.io/generated-by: OpenShiftNewApp
+        template.alpha.openshift.io/wait-for-ready: "true"
+      labels:
+        app: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/instance: postgresql
+        template: postgresql-ephemeral-template
+      name: postgresql
+    spec:
+      replicas: 1
+      selector:
+        name: postgresql
+      strategy:
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            openshift.io/generated-by: OpenShiftNewApp
+          creationTimestamp: null
+          labels:
+            name: postgresql
+        spec:
+          containers:
+            - env:
+                - name: POSTGRESQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-user
+                      name: postgresql
+                - name: POSTGRESQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-password
+                      name: postgresql
+                - name: POSTGRESQL_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-name
+                      name: postgresql
+              image: ' '
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                exec:
+                  command:
+                    - /usr/libexec/check-container
+                    - --live
+                initialDelaySeconds: 120
+                timeoutSeconds: 10
+              name: postgresql
+              ports:
+                - containerPort: 5432
+                  protocol: TCP
+              readinessProbe:
+                exec:
+                  command:
+                    - /usr/libexec/check-container
+                initialDelaySeconds: 5
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  memory: 512Mi
+              securityContext:
+                capabilities: {}
+                privileged: false
+              terminationMessagePath: /dev/termination-log
+              volumeMounts:
+                - mountPath: /var/lib/pgsql/data
+                  name: postgresql-data
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          volumes:
+            - emptyDir: {}
+              name: postgresql-data
+      test: false
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - postgresql
+            from:
+              kind: ImageStreamTag
+              name: postgresql:10-el8
+              namespace: openshift
+          type: ImageChange
+        - type: ConfigChange
+    status:
+      availableReplicas: 0
+      latestVersion: 0
+      observedGeneration: 0
+      replicas: 0
+      unavailableReplicas: 0
+      updatedReplicas: 0
+kind: List
+metadata: {}

--- a/use-cases/school-timetabling/src/main/resources/application.properties
+++ b/use-cases/school-timetabling/src/main/resources/application.properties
@@ -57,12 +57,12 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 ########################
 # Optional overrides for use in OpenShift
 ########################
-%openshift.quarkus.openshift.name=school-timetabling
-%openshift.quarkus.openshift.route.expose=true
-%openshift.quarkus.datasource.db-kind=postgresql
-%openshift.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql/app
+%openshift-native.quarkus.openshift.name=school-timetabling
+%openshift-native.quarkus.openshift.route.expose=true
+%openshift-native.quarkus.datasource.db-kind=postgresql
+%openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql/app
 
 # Note: Do not store username and password in application.properties for a production application;
 #       Use .env or environment variables instead
-%openshift.quarkus.datasource.username=app
-%openshift.quarkus.datasource.password=app
+%openshift-native.quarkus.datasource.username=app
+%openshift-native.quarkus.datasource.password=app

--- a/use-cases/school-timetabling/src/main/resources/application.properties
+++ b/use-cases/school-timetabling/src/main/resources/application.properties
@@ -55,14 +55,14 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
 
 ########################
-# OpenShift overrides
+# Optional overrides for use in OpenShift
 ########################
 %openshift.quarkus.openshift.name=school-timetabling
 %openshift.quarkus.openshift.route.expose=true
 %openshift.quarkus.datasource.db-kind=postgresql
 %openshift.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql/app
 
-# Do not store username and password in application.properties for a production application;
-# Use .env or environment variables instead
+# Note: Do not store username and password in application.properties for a production application;
+#       Use .env or environment variables instead
 %openshift.quarkus.datasource.username=app
 %openshift.quarkus.datasource.password=app

--- a/use-cases/school-timetabling/src/main/resources/application.properties
+++ b/use-cases/school-timetabling/src/main/resources/application.properties
@@ -53,3 +53,16 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
+
+########################
+# OpenShift overrides
+########################
+%openshift.quarkus.openshift.name=school-timetabling
+%openshift.quarkus.openshift.route.expose=true
+%openshift.quarkus.datasource.db-kind=postgresql
+%openshift.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql/app
+
+# Do not store username and password in application.properties for a production application;
+# Use .env or environment variables instead
+%openshift.quarkus.datasource.username=app
+%openshift.quarkus.datasource.password=app


### PR DESCRIPTION
To deploy on OpenShift, first login to your OpenShift account using `oc login ...`, then execute the following command in `use-cases/school-timetabling`: 

`mvn clean package -Dopenshift -Dquarkus.kubernetes-client.trust-certs=true -Dquarkus.kubernetes.deploy=true -DskipTests -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman`

`quarkus.kubernetes-client.trust-certs=true ` is if you are using a local instance/a test instance using self-signed certificates. ` -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman` is to force a container build so the native image will run on OpenShift (will get linking issues otherwise). `-Dquarkus.kubernetes.deploy=true` is to deploy automatically after the build (can apply config in `target/kubernetes/openshift.yml` instead)
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2657

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
