### PR TITLE
PLANNER-2657: Add native openshift instructions for all use cases

### DIFF
--- a/technology/kotlin-quarkus/README.adoc
+++ b/technology/kotlin-quarkus/README.adoc
@@ -100,6 +100,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `technology/kotlin-quarkus` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see two pods in the Topology view: one for the _ephemeral_ Postgres database (data will not be saved), and one for the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -247,6 +247,28 @@
         <quarkus.profile>native</quarkus.profile>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/technology/kotlin-quarkus/src/main/kubernetes/openshift.yml
+++ b/technology/kotlin-quarkus/src/main/kubernetes/openshift.yml
@@ -1,0 +1,145 @@
+apiVersion: v1
+items:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      annotations:
+        template.openshift.io/expose-database_name: '{.data[''database-name'']}'
+        template.openshift.io/expose-password: '{.data[''database-password'']}'
+        template.openshift.io/expose-username: '{.data[''database-user'']}'
+      labels:
+        app: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/part-of: kotlin-school-timetabling
+        template: postgresql-ephemeral-template
+      name: postgresql-kotlin-school-timetabling
+    stringData:
+      database-name: app
+      database-password: app
+      database-user: app
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        openshift.io/generated-by: OpenShiftNewApp
+        template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
+      labels:
+        app: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/part-of: kotlin-school-timetabling
+        template: postgresql-ephemeral-template
+      name: postgresql-kotlin-school-timetabling
+    spec:
+      ports:
+        - name: postgresql-kotlin-school-timetabling
+          port: 5432
+          protocol: TCP
+          targetPort: 5432
+      selector:
+        name: postgresql
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        openshift.io/generated-by: OpenShiftNewApp
+        template.alpha.openshift.io/wait-for-ready: "true"
+      labels:
+        app: postgresql
+        app.kubernetes.io/component: postgresql
+        app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/part-of: kotlin-school-timetabling
+        template: postgresql-ephemeral-template
+      name: postgresql-kotlin-school-timetabling
+    spec:
+      replicas: 1
+      selector:
+        name: postgresql
+      strategy:
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            openshift.io/generated-by: OpenShiftNewApp
+          creationTimestamp: null
+          labels:
+            name: postgresql
+        spec:
+          containers:
+            - env:
+                - name: POSTGRESQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-user
+                      name: postgresql-kotlin-school-timetabling
+                - name: POSTGRESQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-password
+                      name: postgresql-kotlin-school-timetabling
+                - name: POSTGRESQL_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-name
+                      name: postgresql-kotlin-school-timetabling
+              image: ' '
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                exec:
+                  command:
+                    - /usr/libexec/check-container
+                    - --live
+                initialDelaySeconds: 120
+                timeoutSeconds: 10
+              name: postgresql
+              ports:
+                - containerPort: 5432
+                  protocol: TCP
+              readinessProbe:
+                exec:
+                  command:
+                    - /usr/libexec/check-container
+                initialDelaySeconds: 5
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  memory: 512Mi
+              securityContext:
+                capabilities: {}
+                privileged: false
+              terminationMessagePath: /dev/termination-log
+              volumeMounts:
+                - mountPath: /var/lib/pgsql/data
+                  name: postgresql-data
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          volumes:
+            - emptyDir: {}
+              name: postgresql-data
+      test: false
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - postgresql
+            from:
+              kind: ImageStreamTag
+              name: postgresql:10-el8
+              namespace: openshift
+          type: ImageChange
+        - type: ConfigChange
+    status:
+      availableReplicas: 0
+      latestVersion: 0
+      observedGeneration: 0
+      replicas: 0
+      unavailableReplicas: 0
+      updatedReplicas: 0
+kind: List
+metadata: {}

--- a/technology/kotlin-quarkus/src/main/resources/application.properties
+++ b/technology/kotlin-quarkus/src/main/resources/application.properties
@@ -52,3 +52,18 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:school-timetabling
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=kotlin-school-timetabling
+%openshift-native.quarkus.openshift.part-of=kotlin-school-timetabling
+%openshift-native.quarkus.openshift.route.expose=true
+%openshift-native.quarkus.datasource.db-kind=postgresql
+%openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql-kotlin-school-timetabling/app
+
+# Note: Do not store username and password in application.properties for a production application;
+#       Use .env or environment variables instead
+%openshift-native.quarkus.datasource.username=app
+%openshift-native.quarkus.datasource.password=app
+

--- a/use-cases/call-center/README.adoc
+++ b/use-cases/call-center/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/call-center` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see one pod in the Topology view: the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -170,6 +170,24 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/call-center/src/main/resources/application.properties
+++ b/use-cases/call-center/src/main/resources/application.properties
@@ -30,3 +30,10 @@ quarkus.optaplanner.solver.daemon=true
 
 # XML file for power tweaking, defaults to solverConfig.xml (directly under src/main/resources)
 # quarkus.optaplanner.solver-config-xml=org/.../callCenterSolverConfig.xml
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=call-center
+%openshift-native.quarkus.openshift.part-of=call-center
+%openshift-native.quarkus.openshift.route.expose=true

--- a/use-cases/employee-scheduling/README.adoc
+++ b/use-cases/employee-scheduling/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/employee-scheduling` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see two pods in the Topology view: one for the _ephemeral_ Postgres database (data will not be saved), and one for the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -189,6 +189,28 @@
         <quarkus.profile>native</quarkus.profile>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/employee-scheduling/src/main/kubernetes/openshift.yml
+++ b/use-cases/employee-scheduling/src/main/kubernetes/openshift.yml
@@ -11,9 +11,9 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
-        app.kubernetes.io/part-of: school-timetabling
+        app.kubernetes.io/part-of: employee-scheduling
         template: postgresql-ephemeral-template
-      name: postgresql-school-timetabling
+      name: postgresql-employee-scheduling
     stringData:
       database-name: app
       database-password: app
@@ -28,12 +28,12 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
-        app.kubernetes.io/part-of: school-timetabling
+        app.kubernetes.io/part-of: employee-scheduling
         template: postgresql-ephemeral-template
-      name: postgresql-school-timetabling
+      name: postgresql-employee-scheduling
     spec:
       ports:
-        - name: postgresql-school-timetabling
+        - name: postgresql-employee-scheduling
           port: 5432
           protocol: TCP
           targetPort: 5432
@@ -53,9 +53,9 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
-        app.kubernetes.io/part-of: school-timetabling
+        app.kubernetes.io/part-of: employee-scheduling
         template: postgresql-ephemeral-template
-      name: postgresql-school-timetabling
+      name: postgresql-employee-scheduling
     spec:
       replicas: 1
       selector:
@@ -77,17 +77,17 @@ items:
                   valueFrom:
                     secretKeyRef:
                       key: database-user
-                      name: postgresql-school-timetabling
+                      name: postgresql-employee-scheduling
                 - name: POSTGRESQL_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       key: database-password
-                      name: postgresql-school-timetabling
+                      name: postgresql-employee-scheduling
                 - name: POSTGRESQL_DATABASE
                   valueFrom:
                     secretKeyRef:
                       key: database-name
-                      name: postgresql-school-timetabling
+                      name: postgresql-employee-scheduling
               image: ' '
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/use-cases/employee-scheduling/src/main/resources/application.properties
+++ b/use-cases/employee-scheduling/src/main/resources/application.properties
@@ -52,3 +52,20 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:employee-scheduling
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=employee-scheduling
+%openshift-native.quarkus.openshift.part-of=employee-scheduling
+%openshift-native.quarkus.openshift.route.expose=true
+%openshift-native.quarkus.datasource.db-kind=postgresql
+%openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql-employee-scheduling/app
+# Shift has field end, which is a reserved keyword in postgres (end is not a keyword in H2),
+# so we globally quote all identifiers to prevent issues.
+%openshift-native.quarkus.hibernate-orm.database.globally-quoted-identifiers=true
+
+# Note: Do not store username and password in application.properties for a production application;
+#       Use .env or environment variables instead
+%openshift-native.quarkus.datasource.username=app
+%openshift-native.quarkus.datasource.password=app

--- a/use-cases/facility-location/README.adoc
+++ b/use-cases/facility-location/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/facility-location` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see one pod in the Topology view: the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -166,6 +166,24 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/facility-location/src/main/resources/application.properties
+++ b/use-cases/facility-location/src/main/resources/application.properties
@@ -27,3 +27,10 @@ quarkus.log.category."org.optaplanner".level=DEBUG
 # Effectively disable spent-time termination in favor of the best-score-limit
 %test.quarkus.optaplanner.solver.termination.spent-limit=1h
 %test.quarkus.optaplanner.solver.termination.best-score-limit=0hard/*soft
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=facility-location
+%openshift-native.quarkus.openshift.part-of=facility-location
+%openshift-native.quarkus.openshift.route.expose=true

--- a/use-cases/maintenance-scheduling/README.adoc
+++ b/use-cases/maintenance-scheduling/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/maintenance-scheduling` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see two pods in the Topology view: one for the _ephemeral_ Postgres database (data will not be saved), and one for the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -189,6 +189,28 @@
         <quarkus.profile>native</quarkus.profile>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/maintenance-scheduling/src/main/kubernetes/openshift.yml
+++ b/use-cases/maintenance-scheduling/src/main/kubernetes/openshift.yml
@@ -11,9 +11,9 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
-        app.kubernetes.io/part-of: school-timetabling
+        app.kubernetes.io/part-of: maintenance-scheduling
         template: postgresql-ephemeral-template
-      name: postgresql-school-timetabling
+      name: postgresql-maintenance-scheduling
     stringData:
       database-name: app
       database-password: app
@@ -28,12 +28,12 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
-        app.kubernetes.io/part-of: school-timetabling
+        app.kubernetes.io/part-of: maintenance-scheduling
         template: postgresql-ephemeral-template
-      name: postgresql-school-timetabling
+      name: postgresql-maintenance-scheduling
     spec:
       ports:
-        - name: postgresql-school-timetabling
+        - name: postgresql-maintenance-scheduling
           port: 5432
           protocol: TCP
           targetPort: 5432
@@ -53,9 +53,9 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
-        app.kubernetes.io/part-of: school-timetabling
+        app.kubernetes.io/part-of: maintenance-scheduling
         template: postgresql-ephemeral-template
-      name: postgresql-school-timetabling
+      name: postgresql-maintenance-scheduling
     spec:
       replicas: 1
       selector:
@@ -77,17 +77,17 @@ items:
                   valueFrom:
                     secretKeyRef:
                       key: database-user
-                      name: postgresql-school-timetabling
+                      name: postgresql-maintenance-scheduling
                 - name: POSTGRESQL_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       key: database-password
-                      name: postgresql-school-timetabling
+                      name: postgresql-maintenance-scheduling
                 - name: POSTGRESQL_DATABASE
                   valueFrom:
                     secretKeyRef:
                       key: database-name
-                      name: postgresql-school-timetabling
+                      name: postgresql-maintenance-scheduling
               image: ' '
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/use-cases/maintenance-scheduling/src/main/resources/application.properties
+++ b/use-cases/maintenance-scheduling/src/main/resources/application.properties
@@ -52,3 +52,17 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # In pom.xml, the "native" maven profile triggers the "native" quarkus profile.
 %native.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:maintenance-scheduling
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=maintenance-scheduling
+%openshift-native.quarkus.openshift.part-of=maintenance-scheduling
+%openshift-native.quarkus.openshift.route.expose=true
+%openshift-native.quarkus.datasource.db-kind=postgresql
+%openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql-maintenance-scheduling/app
+
+# Note: Do not store username and password in application.properties for a production application;
+#       Use .env or environment variables instead
+%openshift-native.quarkus.datasource.username=app
+%openshift-native.quarkus.datasource.password=app

--- a/use-cases/order-picking/README.adoc
+++ b/use-cases/order-picking/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/order-picking` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see one pod in the Topology view: the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -167,6 +167,24 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/order-picking/src/main/resources/application.properties
+++ b/use-cases/order-picking/src/main/resources/application.properties
@@ -31,3 +31,10 @@ quarkus.optaplanner.solver.termination.spent-limit=5m
 
 # XML file for power tweaking, defaults to solverConfig.xml (directly under src/main/resources)
 # quarkus.optaplanner.solver-config-xml=org/.../orderPickingSolverConfig.xml
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=order-picking
+%openshift-native.quarkus.openshift.part-of=order-picking
+%openshift-native.quarkus.openshift.route.expose=true

--- a/use-cases/school-timetabling/src/main/kubernetes/openshift.yml
+++ b/use-cases/school-timetabling/src/main/kubernetes/openshift.yml
@@ -11,6 +11,7 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/part-of: school-timetabling
         template: postgresql-ephemeral-template
       name: postgresql
     stringData:
@@ -27,6 +28,7 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/part-of: school-timetabling
         template: postgresql-ephemeral-template
       name: postgresql
     spec:
@@ -51,6 +53,7 @@ items:
         app: postgresql
         app.kubernetes.io/component: postgresql
         app.kubernetes.io/instance: postgresql
+        app.kubernetes.io/part-of: school-timetabling
         template: postgresql-ephemeral-template
       name: postgresql
     spec:

--- a/use-cases/school-timetabling/src/main/resources/application.properties
+++ b/use-cases/school-timetabling/src/main/resources/application.properties
@@ -58,6 +58,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # Optional overrides for use in OpenShift
 ########################
 %openshift-native.quarkus.openshift.name=school-timetabling
+%openshift-native.quarkus.openshift.labels."app.kubernetes.io/part-of"=school-timetabling
 %openshift-native.quarkus.openshift.route.expose=true
 %openshift-native.quarkus.datasource.db-kind=postgresql
 %openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql/app

--- a/use-cases/school-timetabling/src/main/resources/application.properties
+++ b/use-cases/school-timetabling/src/main/resources/application.properties
@@ -58,10 +58,10 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 # Optional overrides for use in OpenShift
 ########################
 %openshift-native.quarkus.openshift.name=school-timetabling
-%openshift-native.quarkus.openshift.labels."app.kubernetes.io/part-of"=school-timetabling
+%openshift-native.quarkus.openshift.part-of=school-timetabling
 %openshift-native.quarkus.openshift.route.expose=true
 %openshift-native.quarkus.datasource.db-kind=postgresql
-%openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql/app
+%openshift-native.quarkus.datasource.jdbc.url=jdbc:postgresql://postgresql-school-timetabling/app
 
 # Note: Do not store username and password in application.properties for a production application;
 #       Use .env or environment variables instead

--- a/use-cases/vaccination-scheduling/README.adoc
+++ b/use-cases/vaccination-scheduling/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/vaccination-scheduling` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see one pod in the Topology view: the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -181,6 +181,24 @@
         <quarkus.profile>native</quarkus.profile>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/vaccination-scheduling/src/main/resources/application.properties
+++ b/use-cases/vaccination-scheduling/src/main/resources/application.properties
@@ -31,3 +31,10 @@ quarkus.optaplanner.solver.termination.spent-limit=5m
 quarkus.log.category."org.optaplanner".level=DEBUG
 %test.quarkus.log.category."org.optaplanner".level=INFO
 %prod.quarkus.log.category."org.optaplanner".level=INFO
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=vaccination-scheduling
+%openshift-native.quarkus.openshift.part-of=vaccination-scheduling
+%openshift-native.quarkus.openshift.route.expose=true

--- a/use-cases/vehicle-routing/README.adoc
+++ b/use-cases/vehicle-routing/README.adoc
@@ -95,6 +95,34 @@ To deploy the application on OpenShift:
 .. Open the URL (click on the top right icon).
 . Click on the *Solve* button.
 
+=== Host it on OpenShift using native build
+
+Requirements:
+
+- Install https://podman.io/[Podman] or https://www.docker.com/[Docker]
+- Install https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift Client (oc) tools]
+
+To deploy the application on OpenShift using the native build:
+
+. https://developers.redhat.com/developer-sandbox[Get a free Developer Sandbox account for OpenShift] and _launch_ the Developer Sandbox.
+. In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
+. In the OpenShift web console, click your username (in the upper right corner) and select the "Copy login command" option.
+. In a bash terminal on your local machine, paste the login command.
+. In a local clone of the repo, navigate to the `use-cases/vehicle-routing` directory.
+. Run the command below:
++
+[source, shell]
+----
+$ mvn clean package -DskipTests -Dopenshift-native -Dquarkus.kubernetes.deploy=true -Dquarkus.native.container-build=true
+----
++
+. When the command is finished, you should see one pod in the Topology view: the _native_ Quarkus application. If you click the Quarkus' application link (small bubble with link icon at the top right of the Quarkus' application bubble), you will be navigated to the application. Alternatively, you can get the route from bash with the following command:
++
+[source, shell]
+----
+$ oc get routes
+----
+
 
 [[native]]
 == Run it native

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -181,6 +181,24 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>openshift-native</id> <!-- Optional for use in OpenShift. -->
+      <activation>
+        <property>
+          <name>openshift-native</name>
+        </property>
+      </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.profile>openshift-native</quarkus.profile>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-openshift</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <repositories>

--- a/use-cases/vehicle-routing/src/main/resources/application.properties
+++ b/use-cases/vehicle-routing/src/main/resources/application.properties
@@ -27,3 +27,10 @@ quarkus.log.category."org.optaplanner".level=DEBUG
 # Effectively disable this termination in favor of the best-score-limit
 %test.quarkus.optaplanner.solver.termination.spent-limit=1h
 %test.quarkus.optaplanner.solver.termination.best-score-limit=0hard/*soft
+
+########################
+# Optional overrides for use in OpenShift
+########################
+%openshift-native.quarkus.openshift.name=vehicle-routing
+%openshift-native.quarkus.openshift.part-of=vehicle-routing
+%openshift-native.quarkus.openshift.route.expose=true


### PR DESCRIPTION
Prefix the database name with quickstart name, so all quickstarts can be in the same OpenShift project
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
https://issues.redhat.com/browse/PLANNER-2657

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
