### PR TITLE
PLANNER-2678 Make TimeTableResourceTest call the resource through HTTP

### DIFF
--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -26,14 +26,16 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-data-rest"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
-    runtimeOnly "com.h2database:h2"
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation "io.rest-assured:rest-assured"
+    testImplementation "org.awaitility:awaitility"
 
     implementation platform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation "org.optaplanner:optaplanner-spring-boot-starter"
     testImplementation("org.optaplanner:optaplanner-test")
     testImplementation("org.optaplanner:optaplanner-benchmark")
 
+    runtimeOnly "com.h2database:h2"
     runtimeOnly "org.webjars:webjars-locator:0.37"
     runtimeOnly "org.webjars:bootstrap:4.3.1"
     runtimeOnly "org.webjars:font-awesome:5.11.2"

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -76,6 +76,16 @@
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- UI -->
     <dependency>

--- a/technology/java-spring-boot/src/test/java/org/acme/schooltimetabling/rest/TimeTableControllerTest.java
+++ b/technology/java-spring-boot/src/test/java/org/acme/schooltimetabling/rest/TimeTableControllerTest.java
@@ -1,44 +1,50 @@
 package org.acme.schooltimetabling.rest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
-import org.acme.schooltimetabling.domain.Lesson;
-import org.acme.schooltimetabling.domain.TimeTable;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.SolverStatus;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import java.time.Duration;
 
 @SpringBootTest(properties = {
         // Effectively disable spent-time termination in favor of the best-score-limit
         "optaplanner.solver.termination.spent-limit=1h",
-        "optaplanner.solver.termination.best-score-limit=0hard/*soft"})
+        "optaplanner.solver.termination.best-score-limit=0hard/*soft" },
+        webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class TimeTableControllerTest {
-
-    @Autowired
-    private TimeTableController timeTableController;
 
     @Test
     @Timeout(600_000)
-    public void solveDemoDataUntilFeasible() throws InterruptedException {
-        timeTableController.solve();
-        TimeTable timeTable;
-        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
-            // Quick polling (not a Test Thread Sleep anti-pattern)
-            // Test is still fast on fast machines and doesn't randomly fail on slow machines.
-            Thread.sleep(20L);
-            timeTable = timeTableController.getTimeTable();
-        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING || !timeTable.getScore().isFeasible());
+    public void solveDemoDataUntilFeasible() {
+        given()
+                .contentType(ContentType.JSON)
+                .when().post("/timeTable/solve")
+                .then()
+                .statusCode(200);
 
-        assertFalse(timeTable.getLessonList().isEmpty());
-        for (Lesson lesson : timeTable.getLessonList()) {
-            assertNotNull(lesson.getTimeslot());
-            assertNotNull(lesson.getRoom());
-        }
-        assertTrue(timeTable.getScore().isFeasible());
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .pollDelay(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofSeconds(5))
+                .until(() -> SolverStatus.NOT_SOLVING.name().equals(get("/timeTable").body().path("solverStatus")));
+
+        get("/timeTable").then().assertThat()
+                .body("solverStatus", equalTo(SolverStatus.NOT_SOLVING.name()))
+                .body("timeslotList", is(not(empty())))
+                .body("roomList", is(not(empty())))
+                .body("lessonList", is(not(empty())))
+                .body("lessonList.timeslot", not(nullValue()))
+                .body("lessonList.room", not(nullValue()));
     }
 
 }

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -109,6 +109,11 @@
       <artifactId>optaplanner-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- UI -->
     <dependency>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation "io.quarkus:quarkus-junit5"
     testImplementation "io.quarkus:quarkus-test-h2"
     testImplementation "io.rest-assured:rest-assured"
+    testImplementation "org.awaitility:awaitility"
 
     implementation platform("org.optaplanner:optaplanner-bom:${optaplannerVersion}")
     implementation "org.optaplanner:optaplanner-quarkus"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>optaplanner-quarkus-benchmark</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- UI -->
     <dependency>

--- a/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
+++ b/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeTableResourceTest.java
@@ -1,43 +1,45 @@
 package org.acme.schooltimetabling.rest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
-import javax.inject.Inject;
+import java.time.Duration;
 
-import org.acme.schooltimetabling.domain.Lesson;
-import org.acme.schooltimetabling.domain.TimeTable;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.optaplanner.core.api.solver.SolverStatus;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class TimeTableResourceTest {
 
-    @Inject
-    TimeTableResource timeTableResource;
-
     @Test
-    @Timeout(600_000)
-    public void solveDemoDataUntilFeasible() throws InterruptedException {
-        timeTableResource.solve();
-        TimeTable timeTable;
-        do { // Use do-while to give the solver some time and avoid retrieving an early infeasible solution.
-            // Quick polling (not a Test Thread Sleep anti-pattern)
-            // Test is still fast on fast machines and doesn't randomly fail on slow machines.
-            Thread.sleep(20L);
-            timeTable = timeTableResource.getTimeTable();
-        } while (timeTable.getSolverStatus() != SolverStatus.NOT_SOLVING || !timeTable.getScore().isFeasible());
+    public void solveDemoDataUntilFeasible() {
+        given()
+                .contentType(ContentType.JSON)
+                .when().post("/timeTable/solve")
+                .then()
+                .statusCode(204);
 
-        assertFalse(timeTable.getLessonList().isEmpty());
-        for (Lesson lesson : timeTable.getLessonList()) {
-            assertNotNull(lesson.getTimeslot());
-            assertNotNull(lesson.getRoom());
-        }
-        assertTrue(timeTable.getScore().isFeasible());
+        await()
+                .atMost(Duration.ofMinutes(1))
+                .pollDelay(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofSeconds(5))
+                .until(() -> SolverStatus.NOT_SOLVING.name().equals(get("/timeTable").body().path("solverStatus")));
+
+        get("/timeTable").then().assertThat()
+                .body("solverStatus", equalTo(SolverStatus.NOT_SOLVING.name()))
+                .body("timeslotList", is(not(empty())))
+                .body("roomList", is(not(empty())))
+                .body("lessonList", is(not(empty())))
+                .body("lessonList.timeslot", not(nullValue()))
+                .body("lessonList.room", not(nullValue()));
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
