### PR TITLE
Fix runQuickstartsFromSource.bat

### DIFF
--- a/build/quickstarts-showcase/src/main/java/org/optaplanner/quickstarts/all/rest/QuickstartLauncherResource.java
+++ b/build/quickstarts-showcase/src/main/java/org/optaplanner/quickstarts/all/rest/QuickstartLauncherResource.java
@@ -21,7 +21,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +33,6 @@ import javax.enterprise.event.Observes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -42,7 +43,7 @@ import org.slf4j.LoggerFactory;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 
-@Path("quickstart")
+@javax.ws.rs.Path("quickstart")
 public class QuickstartLauncherResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QuickstartLauncherResource.class);
@@ -55,7 +56,7 @@ public class QuickstartLauncherResource {
     private List<QuickstartMeta> quickstartMetaList;
     private boolean development;
     private int nextPort = 8081;
-    private File baseDirectory;
+    private Path baseDirectory;
 
     private Map<Integer, Process> portToProcessMap;
 
@@ -69,25 +70,17 @@ public class QuickstartLauncherResource {
                 new QuickstartMeta("vehicle-routing"),
                 new QuickstartMeta("order-picking"),
                 new QuickstartMeta("employee-scheduling"));
-        File workingDirectory;
-        try {
-            workingDirectory = new File(".").getCanonicalFile();
-        } catch (IOException e) {
-            throw new IllegalStateException("Could not determine the workingDirectory.", e);
-        }
-        if (new File(workingDirectory, "target").exists()) {
-            baseDirectory = new File(workingDirectory, "../..");
+        Path workingDirectory = Paths.get("").toAbsolutePath();
+        if (Files.exists(workingDirectory.resolve("target"))) {
+            baseDirectory = workingDirectory.getParent().getParent();
             development = true;
         } else {
-            baseDirectory = new File(workingDirectory, "quickstarts/binaries");
+            baseDirectory = workingDirectory.resolve(Paths.get("quickstarts", "binaries"));
             development = false;
         }
         portToProcessMap = new HashMap<>(quickstartMetaList.size());
-        try {
-            baseDirectory = baseDirectory.getCanonicalFile();
-        } catch (IOException e) {
-            throw new IllegalStateException("Could not canonicalize baseDirectory (" + baseDirectory + ").", e);
-        }
+        baseDirectory = baseDirectory.toAbsolutePath();
+
         if (startupOpenBrowser) {
             openInBrowser(httpPort);
         }
@@ -107,7 +100,7 @@ public class QuickstartLauncherResource {
         return quickstartMetaList;
     }
 
-    @Path("{quickstartId}/launch")
+    @javax.ws.rs.Path("{quickstartId}/launch")
     @POST
     public void launchQuickstart(@PathParam("quickstartId") String quickstartId) {
         QuickstartMeta quickstartMeta = quickstartMetaList.stream()
@@ -123,14 +116,19 @@ public class QuickstartLauncherResource {
         String corsArg = "-Dquarkus.http.cors=true";
         this.nextPort++;
         if (development) {
-            String mvnCommand = System.getProperty("os.name").startsWith("Windows") ? "mvnw.cmd" : "./mvnw";
+            String mvnCommand;
+            if (System.getProperty("os.name").startsWith("Windows")) {
+                mvnCommand = baseDirectory.resolve(Paths.get("build", "mvnw.cmd")).toString();
+            } else {
+                mvnCommand = baseDirectory.resolve(Paths.get("build", "mvnw")).toString();
+            }
             processBuilder = new ProcessBuilder(mvnCommand, "-f", "../use-cases/" + quickstartId, "quarkus:dev", portArg,
                     corsArg, "-Ddebug=false");
-            processBuilder.directory(new File(baseDirectory, "build"));
+            processBuilder.directory(baseDirectory.resolve("build").toFile());
         } else {
             processBuilder = new ProcessBuilder("java", portArg, corsArg, "-jar",
                     getQuickstartRunnerJar(quickstartId).getAbsolutePath());
-            processBuilder.directory(new File(new File(baseDirectory, "use-cases"), quickstartId));
+            processBuilder.directory(baseDirectory.resolve(Paths.get("use-cases", quickstartId)).toFile());
         }
         processBuilder.inheritIO();
         Process process;
@@ -147,9 +145,9 @@ public class QuickstartLauncherResource {
     }
 
     private File getQuickstartRunnerJar(String quickstartId) {
-        File quickstartRunnerJar = FileSystems.getDefault().getPath(baseDirectory.getAbsolutePath(),
+        File quickstartRunnerJar = baseDirectory.resolve(Paths.get(
                 "use-cases", quickstartId,
-                "quarkus-app", "quarkus-run.jar").toFile();
+                "quarkus-app", "quarkus-run.jar")).toFile();
         if (!quickstartRunnerJar.exists()) {
             throw new IllegalStateException(
                     "The quickstart (" + quickstartId + ") runner JAR file does not exist ("
@@ -158,7 +156,7 @@ public class QuickstartLauncherResource {
         return quickstartRunnerJar;
     }
 
-    @Path("{quickstartId}/stop/{port}")
+    @javax.ws.rs.Path("{quickstartId}/stop/{port}")
     @DELETE
     public void stopQuickstart(@PathParam("quickstartId") String quickstartId, @PathParam("port") int port) {
         QuickstartMeta quickstartMeta = quickstartMetaList.stream()

--- a/runQuickstartsFromSource.bat
+++ b/runQuickstartsFromSource.bat
@@ -2,6 +2,7 @@
 setLocal enableExtensions enableDelayedExpansion
 
 cd build
-mvnw verify -DskipTests && ^
+mvnw -f .. verify -DskipTests && cd build && ^
 mvnw -f quickstarts-showcase quarkus:dev -Dstartup-open-browser=true
+cd ..
 cd ..


### PR DESCRIPTION
Commit 35912dd2e55bf70fe94604edf3ed87b69121d8bd updated `.sh` version
of the script to run from ".." but ran the `.bat` version of the script from ".", which
leads to "mvnw.cmd" not being found. Because of this, the quickstart launcher does
not build or launch in Windows using runQuickstartsFromSource.bat.

After this fix, the quickstart launcher does build and launch. However,
there is still an issue where the quickstarts do not launch on Windows, complaining
"mvnw" not being found (despite the path in the error existing). This issue would need
to be fixed in the Java files.

In regards to the many cd commands: Windows does not revert the
working directory to it previous state after running commands. So
`mvnw -f ..` changes the working directory back to the parent,
so we need to back into build again. And then an extra cd to get
out of quickstarts-showcase.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
