### PR TITLE
CI status webpage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,4 +43,4 @@ How to retest this PR or trigger a specific build:
 
 ### CI Status
 
- You can check Optaplanner organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/)
+You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,3 +40,7 @@ How to retest this PR or trigger a specific build:
 * for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
 * for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
 </details>
+
+### CI Status
+
+ You can check Optaplanner organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/)


### PR DESCRIPTION
### Referenced pull requests

* https://github.com/kiegroup/optaplanner/pull/1889
* https://github.com/kiegroup/optaplanner-quickstarts/pull/312
* https://github.com/kiegroup/optaweb-employee-rostering/pull/781
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/668

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
