### PR TITLE
PLANNER-2681 Remove incremental methods from ProblemChangeDirector

### DIFF
--- a/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/AddCallProblemChange.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/AddCallProblemChange.java
@@ -31,6 +31,6 @@ public class AddCallProblemChange implements ProblemChange<CallCenter> {
 
     @Override
     public void doChange(CallCenter workingCallCenter, ProblemChangeDirector problemChangeDirector) {
-        problemChangeDirector.addEntity(call, workingCallCenter.getCalls()::add);
+        workingCallCenter.getCalls().add(call);
     }
 }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/PinCallProblemChange.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/PinCallProblemChange.java
@@ -33,9 +33,8 @@ public class PinCallProblemChange implements ProblemChange<CallCenter> {
 
     @Override
     public void doChange(CallCenter workingCallCenter, ProblemChangeDirector problemChangeDirector) {
-        problemChangeDirector.changeProblemProperty(call, workingCall -> {
-            workingCall.setPinned(true);
-            workingCall.setPickUpTime(LocalTime.now());
-        });
+        Call workingCall = problemChangeDirector.lookUpWorkingObjectOrFail(call);
+        workingCall.setPinned(true);
+        workingCall.setPickUpTime(LocalTime.now());
     }
 }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/ProlongCallByMinuteProblemChange.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/ProlongCallByMinuteProblemChange.java
@@ -34,9 +34,7 @@ public class ProlongCallByMinuteProblemChange implements ProblemChange<CallCente
 
     @Override
     public void doChange(CallCenter workingSolution, ProblemChangeDirector problemChangeDirector) {
-        Call call = new Call(callId, null);
-
-        problemChangeDirector.changeProblemProperty(call,
-                workingCall -> workingCall.setDuration(workingCall.getDuration().plus(PROLONGATION)));
+        Call workingCall = problemChangeDirector.lookUpWorkingObjectOrFail(new Call(callId, null));
+        workingCall.setDuration(workingCall.getDuration().plus(PROLONGATION));
     }
 }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/RemoveCallProblemChange.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/solver/change/RemoveCallProblemChange.java
@@ -34,20 +34,17 @@ public class RemoveCallProblemChange implements ProblemChange<CallCenter> {
 
     @Override
     public void doChange(CallCenter workingCallCenter, ProblemChangeDirector problemChangeDirector) {
-        Call call = new Call(callId, null);
-        Optional<Call> workingCallOptional = problemChangeDirector.lookUpWorkingObject(call);
+        Optional<Call> workingCallOptional = problemChangeDirector.lookUpWorkingObject(new Call(callId, null));
         workingCallOptional.ifPresent(workingCall -> removeCall(workingCall, workingCallCenter, problemChangeDirector));
     }
 
-    private void removeCall(Call call, CallCenter workingCallCenter, ProblemChangeDirector problemChangeDirector) {
-        PreviousCallOrAgent previousCallOrAgent = call.getPreviousCallOrAgent();
+    private void removeCall(Call workingCall, CallCenter workingCallCenter, ProblemChangeDirector problemChangeDirector) {
+        PreviousCallOrAgent previousCallOrAgent = workingCall.getPreviousCallOrAgent();
 
-        Call nextCall = call.getNextCall();
+        Call nextCall = workingCall.getNextCall();
         if (nextCall != null) {
-            problemChangeDirector.changeVariable(nextCall, "previousCallOrAgent",
-                    workingNextCall -> workingNextCall.setPreviousCallOrAgent(previousCallOrAgent));
+            nextCall.setPreviousCallOrAgent(previousCallOrAgent);
         }
-
-        problemChangeDirector.removeEntity(call, workingCallCenter.getCalls()::remove);
+        workingCallCenter.getCalls().remove(workingCall);
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2681

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
- https://github.com/kiegroup/optaplanner/pull/1892
- https://github.com/kiegroup/optaplanner-quickstarts/pull/314
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/671

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
