### PR TITLE
bumped up to next 8.20.0-SNAPSHOT

### DIFF
--- a/build/optaplanner-distribution/pom.xml
+++ b/build/optaplanner-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hello-world/build.gradle
+++ b/hello-world/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "application"
 }
 
-def optaplannerVersion = "8.19.0-SNAPSHOT"
+def optaplannerVersion = "8.20.0-SNAPSHOT"
 def logbackVersion = "1.2.9"
 def junitJupiterVersion = "5.8.2"
 

--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
     <version.org.logback>1.2.9</version.org.logback>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0-SNAPSHOT</version>
+    <version>8.20.0-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <!-- IMPORTANT: the individual quickstarts have no parent pom. -->

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <version.org.apache.activemq>2.19.0</version.org.apache.activemq>
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "8.19.0-SNAPSHOT"
+def optaplannerVersion = "8.20.0-SNAPSHOT"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
     <version.org.springframework.boot>2.6.6</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -13,7 +13,7 @@
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 def quarkusVersion = "2.7.3.Final"
-def optaplannerVersion = "8.19.0-SNAPSHOT"
+def optaplannerVersion = "8.20.0-SNAPSHOT"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
     
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
-    <version.org.optaplanner>8.19.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

- https://github.com/kiegroup/optaplanner/pull/1907
- https://github.com/kiegroup/optaplanner/pull/1907
- https://github.com/kiegroup/optaplanner-quickstarts/pull/316
- https://github.com/kiegroup/optaweb-employee-rostering/pull/784
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/674
- https://github.com/kiegroup/kogito-apps/pull/1291
- https://github.com/kiegroup/kogito-examples/pull/1205
- https://github.com/kiegroup/kogito-runtimes/pull/2121)

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
