### PR TITLE
[development] Bump Quarkus version to 2.8.0.Final

### DIFF
--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.apache.activemq>2.19.0</version.org.apache.activemq>
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -84,6 +84,11 @@
         <artifactId>momentjs</artifactId>
         <version>2.24.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.20.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/technology/java-activemq-quarkus/solver/src/test/java/org/acme/schooltimetabling/TimeTableMessagingHandlerIT.java
+++ b/technology/java-activemq-quarkus/solver/src/test/java/org/acme/schooltimetabling/TimeTableMessagingHandlerIT.java
@@ -16,12 +16,11 @@
 
 package org.acme.schooltimetabling;
 
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Disabled;
 
-import io.quarkus.test.junit.NativeImageTest;
-
 @Disabled("The native test hangs after starting the native image and before entering the first test method.")
-@NativeImageTest
+@QuarkusIntegrationTest
 public class TimeTableMessagingHandlerIT extends TimeTableMessagingHandlerTest {
 
 }

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.7.3.Final"
+    id "io.quarkus" version "2.8.0.Final"
 }
 
 def quarkusVersion = "2.8.0.Final"

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "io.quarkus" version "2.7.3.Final"
 }
 
-def quarkusVersion = "2.7.3.Final"
+def quarkusVersion = "2.8.0.Final"
 def optaplannerVersion = "8.20.0-SNAPSHOT"
 
 group = "org.acme"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
     
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/LessonResourceIT.java
+++ b/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/LessonResourceIT.java
@@ -16,9 +16,9 @@
 
 package org.acme.schooltimetabling.rest;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class LessonResourceIT extends LessonResourceTest {
 
 }

--- a/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/RoomResourceIT.java
+++ b/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/RoomResourceIT.java
@@ -16,9 +16,9 @@
 
 package org.acme.schooltimetabling.rest;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class RoomResourceIT extends RoomResourceTest {
 
 }

--- a/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeslotResourceIT.java
+++ b/use-cases/school-timetabling/src/test/java/org/acme/schooltimetabling/rest/TimeslotResourceIT.java
@@ -16,9 +16,9 @@
 
 package org.acme.schooltimetabling.rest;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class TimeslotResourceIT extends TimeslotResourceTest {
 
 }

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.7.3.Final</version.io.quarkus>
+    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.20.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
- https://github.com/kiegroup/optaplanner/pull/1919
- https://github.com/kiegroup/optaplanner-quickstarts/pull/318

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
