### PR TITLE
Change the upload server for distribution

### DIFF
--- a/build/release/upload_distribution.sh
+++ b/build/release/upload_distribution.sh
@@ -3,7 +3,7 @@
 function display_help() {
   readonly script_name="./$(basename "$0")"
 
-  echo "This script uploads the OptaPlanner distribution to the filemgmt.jboss.org."
+  echo "This script uploads the OptaPlanner distribution to the filemgmt-prod.jboss.org."
   echo "Make sure the OptaPlanner Quickstarts project has been build with the full profile enabled before calling this script."
   echo
   echo "Usage:"
@@ -35,7 +35,7 @@ if [[ $# -ne 2 ]]; then
   exit 1
 fi
 
-readonly remote_optaplanner_downloads=optaplanner@filemgmt.jboss.org:/downloads_htdocs/optaplanner
+readonly remote_optaplanner_downloads=optaplanner@filemgmt-prod-sync.jboss.org:/downloads_htdocs/optaplanner
 
 readonly version=$1
 readonly optaplanner_ssh_key=$2
@@ -67,6 +67,6 @@ mkdir -p "$local_optaplanner_downloads/$version"
 # Upload the OptaPlanner distribution.zip.
 cp "$optaplanner_distribution/target/optaplanner-distribution-$version.zip" "$local_optaplanner_downloads/$version"
 
-readonly remote_shell="ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -i $optaplanner_ssh_key"
+readonly remote_shell="ssh -p 2222 -i $optaplanner_ssh_key"
 create_latest_symlinks "$local_optaplanner_downloads" "$version"
 rsync -a -r -e "$remote_shell" --protocol=28 "$local_optaplanner_downloads/.." "$remote_optaplanner_downloads"


### PR DESCRIPTION
Updates the upload server for OptaPlanner distribution. Similar change as for the website: https://github.com/kiegroup/optaplanner-website/pull/487.

Tested by running the script with `--dry-run` added to `rsync`.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
https://github.com/kiegroup/optaplanner/pull/1923

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>

### CI Status

You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).
