### PR TITLE
[8.21.x] Bump Quarkus version to 2.9.0.Final

### DIFF
--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.apache.activemq>2.19.0</version.org.apache.activemq>
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.kotlin>1.5.10</version.kotlin>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
+++ b/use-cases/employee-scheduling/src/main/java/org/acme/employeescheduling/domain/Shift.java
@@ -2,6 +2,7 @@ package org.acme.employeescheduling.domain;
 
 import java.time.LocalDateTime;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -20,6 +21,7 @@ public class Shift {
     Long id;
 
     LocalDateTime start;
+    @Column(name = "endDateTime") // "end" clashes with H2 syntax.
     LocalDateTime end;
 
     String location;

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.8.2.Final"
+    id "io.quarkus" version "2.9.0.Final"
 }
 
-def quarkusVersion = "2.8.2.Final"
+def quarkusVersion = "2.9.0.Final"
 def optaplannerVersion = "8.21.0-SNAPSHOT"
 
 group = "org.acme"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
     
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus>2.9.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.21.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/optaplanner-quickstarts/pull/328

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/437
- https://github.com/kiegroup/drools/pull/4357
- https://github.com/kiegroup/kogito-runtimes/pull/2188
- https://github.com/kiegroup/optaplanner/pull/1967
- https://github.com/kiegroup/optaplanner-quickstarts/pull/330
- https://github.com/kiegroup/kogito-apps/pull/1331
- https://github.com/kiegroup/kogito-examples/pull/1245