### PR TITLE
Update the Spring Boot example to produce an executable JAR

### DIFF
--- a/technology/java-spring-boot/README.adoc
+++ b/technology/java-spring-boot/README.adoc
@@ -36,6 +36,49 @@ $ gradle bootRun
 
 . Click on the *Solve* button.
 
+[[package]]
+== Run the packaged application
+
+When you're ready to deploy the application,
+package the project to run as a conventional jar file.
+
+. Build it with Maven:
++
+[source, shell]
+----
+$ mvn package
+----
++
+or with Gradle:
++
+[source, shell]
+----
+$ gradle clean build
+----
+
+. Run the Maven output:
++
+[source, shell]
+----
+$ java -jar target/optaplanner-spring-boot-school-timetabling-quickstart-1.0-SNAPSHOT.jar
+----
++
+or the Gradle output:
++
+[source, shell]
+----
+$ java -jar build/libs/optaplanner-spring-boot-school-timetabling-quickstart-1.0-SNAPSHOT.jar
+----
++
+[NOTE]
+====
+To run it on port 8081 instead, add `-Dserver.port=8081`.
+====
+
+. Visit http://localhost:8080 in your browser.
+
+. Click on the *Solve* button.
+
 == More information
 
 Visit https://www.optaplanner.org/[www.optaplanner.org].

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -7,6 +7,7 @@ plugins {
 def optaplannerVersion = "8.22.0-SNAPSHOT"
 
 group = "org.acme"
+archivesBaseName = "optaplanner-spring-boot-school-timetabling-quickstart"
 version = "1.0-SNAPSHOT"
 sourceCompatibility = "11"
 

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -117,13 +117,21 @@
         <version>${version.compiler.plugin}</version>
       </plugin>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${version.org.springframework.boot}</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${version.surefire.plugin}</version>
+        <executions>
+          <!-- Repackage the archive produced by maven-jar-plugin into an executable JAR file. -->
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/use-cases/school-timetabling/README.adoc
+++ b/use-cases/school-timetabling/README.adoc
@@ -53,25 +53,32 @@ Notice that those changes are immediately in effect.
 When you're done iterating in `quarkus:dev` mode,
 package the application to run as a conventional jar file.
 
-. Compile it with Maven:
+. Build it with Maven:
 +
 [source, shell]
 ----
 $ mvn package
 ----
 +
-or with gradle:
+or with Gradle:
 +
 [source, shell]
 ----
 $ gradle clean build
 ----
 
-. Run it:
+. Run the Maven output:
 +
 [source, shell]
 ----
 $ java -jar ./target/quarkus-app/quarkus-run.jar
+----
++
+or the Gradle output:
++
+[source, shell]
+----
+$ java -jar ./build/quarkus-app/quarkus-run.jar
 ----
 +
 [NOTE]


### PR DESCRIPTION
The executable JAR is an important feature of the Spring Boot platform.
Since we're not using the spring-boot-starter-parent, the executable JAR
is not built automatically and needs some extra configuration.

Additional changes:
- Align Gradle build output name with Maven build output name.
- Align use-cases/ and technology/ school time tabling readmes.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>full downstream build</b> please add the label `run_fdb`
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
</details>
