### PR TITLE
Update instructions on getting OpenShift

### DIFF
--- a/technology/kubernetes/README.adoc
+++ b/technology/kubernetes/README.adoc
@@ -7,13 +7,12 @@ in terms of maturity and backward compatibility.*
 
 == Get your environment running
 
-Use an existing OpenShift cluster or download and start the https://developers.redhat.com/products/codeready-containers/overview[RedHat CodeReady Containers].
+Use an existing OpenShift cluster or https://developers.redhat.com/products/openshift/download[try any of the options] that fit best your needs.
 
-WARNING: Be sure to pick the _Red Hat OpenShift Local_, as the other option, the _Developer Sandbox for Red Hat OpenShift_ does not
-allow installing new operators.
+WARNING: The _Developer Sandbox for Red Hat OpenShift_ does not allow installing new operators, thus it's not suitable for running this demo.
 
-The CodeReady Containers need more resources to run this demo. Before starting the local cluster, increase the available memory
-at least to 16 384 MiB by running `crc config set memory 16384`.
+WARNING: If you pick the _Red Hat OpenShift Local_, increase the available memory at least to 16 384 MiB
+by running `crc config set memory 16384` before you start the local cluster.
 
 Next, install the https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI (`oc`)]
 to be able to interact with the OpenShift cluster.


### PR DESCRIPTION
Provide more options for getting an OpenShift instance.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
</details>
