### PR TITLE
KOGITO-7786 Setup init-branch jobs

### DIFF
--- a/.ci/jenkins/Jenkinsfile.init-branch
+++ b/.ci/jenkins/Jenkinsfile.init-branch
@@ -48,7 +48,7 @@ pipeline {
                 }
             }
         }
-        stage('Build Optaplanner parents') {
+        stage('Build OptaPlanner parents') {
             steps {
                 script {
                     getMavenCommand(optaplannerRepo)

--- a/.ci/jenkins/Jenkinsfile.init-branch
+++ b/.ci/jenkins/Jenkinsfile.init-branch
@@ -1,0 +1,172 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+optaplannerRepo = 'optaplanner'
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem16g && !master'
+    }
+
+    tools {
+        maven env.BUILD_MAVEN_TOOL
+        jdk env.BUILD_JDK_TOOL
+    }
+
+    options {
+        timestamps()
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    // parameters {
+    // For parameters, check into ./dsl/jobs.groovy file
+    // }
+
+    environment {
+        // Static env is defined into ./dsl/jobs.groovy file
+
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+
+        // Keep here for visitibility
+        MAVEN_OPTS = '-Xms1024m -Xmx4g'
+    }
+
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    cleanWs()
+
+                    if (params.DISPLAY_NAME) {
+                        currentBuild.displayName = params.DISPLAY_NAME
+                    }
+
+                    checkoutRepo(optaplannerRepo, getBuildBranch())
+                    checkoutRepo(getRepoName(), getBuildBranch())
+                }
+            }
+        }
+        stage('Build Optaplanner parents') {
+            steps {
+                script {
+                    getMavenCommand(optaplannerRepo)
+                        .withOptions(['-U', '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom', '-am'])
+                        .run('clean install')
+                }
+            }
+        }
+        stage('Update project version') {
+            steps {
+                script {
+                    maven.mvnSetVersionProperty(getMavenCommand(getRepoName()), 'version.org.optaplanner', getOptaPlannerVersion())
+                    maven.mvnVersionsUpdateParentAndChildModules(getMavenCommand(getRepoName()), getOptaPlannerVersion(), true)
+
+                    dir(getRepoName()) {
+                        sh "find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${getOptaPlannerVersion()}\"/' {} \\;"
+                    }
+                }
+            }
+        }
+        stage('Deploy to repository') {
+            when {
+                expression { return shouldDeployToRepository() }
+            }
+            steps {
+                script {
+                    runMavenDeploy(getRepoName())
+                }
+            }
+        }
+        stage('Update branch') {
+            steps {
+                script {
+                    dir(getRepoName()) {
+                        if (githubscm.isThereAnyChanges()) {
+                            def commitMsg = "Update version to ${getOptaPlannerVersion()}"
+
+                            githubscm.commitChanges(commitMsg, { 
+                                githubscm.findAndStageNotIgnoredFiles('pom.xml') 
+                                githubscm.findAndStageNotIgnoredFiles('build.gradle')
+                            })
+                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
+                        } else {
+                            println '[WARN] no changes to commit'
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendNotification()
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
+            }
+        }
+    }
+}
+
+void sendNotification() {
+    if (params.SEND_NOTIFICATION) {
+        mailer.sendMarkdownTestSummaryNotification('Init', "[${getBuildBranch()}] Optaweb Vehicle Routing", [env.OPTAPLANNER_CI_EMAIL_TO])
+    } else {
+        echo 'No notification sent per configuration'
+    }
+}
+
+void checkoutRepo(String repository, String branch) {
+    dir(repository) {
+        deleteDir()
+        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
+        // need to manually checkout branch since on a detached branch after checkout command
+        sh "git checkout ${branch}"
+    }
+}
+
+boolean shouldDeployToRepository() {
+    return env.MAVEN_DEPLOY_REPOSITORY || getGitAuthor() == 'kiegroup'
+}
+
+String getRepoName() {
+    return env.REPO_NAME
+}
+
+String getGitAuthor() {
+    // GIT_AUTHOR can be env or param
+    return "${GIT_AUTHOR}"
+}
+
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
+}
+
+String getOptaPlannerVersion() {
+    return params.OPTAPLANNER_VERSION
+}
+
+String getGitAuthorCredsID() {
+    return env.AUTHOR_CREDS_ID
+}
+
+MavenCommand getMavenCommand(String directory) {
+    return new MavenCommand(this, ['-fae', '-ntp'])
+                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
+                .inDirectory(directory)
+}
+
+void runMavenDeploy(String directory) {
+    mvnCmd = getMavenCommand(directory)
+
+    mvnCmd.withOptions(['-pl', ':optaplanner-distribution'])
+
+    if (env.MAVEN_DEPLOY_REPOSITORY) {
+        mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
+    }
+
+    mvnCmd.skipTests(true).run('clean deploy')
+}

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -51,7 +51,7 @@ KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'optaplanner-quickstarts', [
 ])
 
 void setupInitBranchJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-quickstarts', Folder.INIT_BRANCH, "${jenkins_path}/Jenkinsfile.init-branch", 'Optaplanner Quickstarts Init branch')
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-quickstarts', Folder.INIT_BRANCH, "${jenkins_path}/Jenkinsfile.init-branch", 'OptaPlanner Quickstarts Init Branch')
     KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
         REPO_NAME: 'optaplanner-quickstarts',
@@ -70,7 +70,7 @@ void setupInitBranchJob() {
 
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
 
-            stringParam('OPTAPLANNER_VERSION', '', 'Optaplanner version to set.')
+            stringParam('OPTAPLANNER_VERSION', '', 'OptaPlanner version to set.')
 
             booleanParam('SEND_NOTIFICATION', false, 'In case you want the pipeline to send a notification on CI channel for this run.')
         }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -8,7 +8,11 @@
 * https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
+import org.kie.jenkins.jobdsl.model.Folder
+import org.kie.jenkins.jobdsl.KogitoJobTemplate
 import org.kie.jenkins.jobdsl.KogitoJobUtils
+
+jenkins_path = '.ci/jenkins'
 
 Map getMultijobPRConfig() {
     return [
@@ -35,6 +39,9 @@ Map getMultijobPRConfig() {
 // Optaplanner PR checks
 KogitoJobUtils.createAllEnvsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig() }
 
+// Init branch
+setupInitBranchJob()
+
 // Tools
 KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'optaplanner-quickstarts', [
     properties: [ 'version.io.quarkus' ],
@@ -42,3 +49,30 @@ KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'optaplanner-quickstarts', [
     // Escaping quotes so it is correctly handled by Json marshalling/unmarshalling
     regex: [ 'id \\"io.quarkus\\" version', 'def quarkusVersion =' ]
 ])
+
+void setupInitBranchJob() {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-quickstarts', Folder.INIT_BRANCH, "${jenkins_path}/Jenkinsfile.init-branch", 'Optaplanner Quickstarts Init branch')
+    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    jobParams.env.putAll([
+        REPO_NAME: 'optaplanner-quickstarts',
+        JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
+
+        GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
+        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+
+        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_DEPENDENCIES_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+        MAVEN_DEPLOY_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
+    ])
+    KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+
+            stringParam('OPTAPLANNER_VERSION', '', 'Optaplanner version to set.')
+
+            booleanParam('SEND_NOTIFICATION', false, 'In case you want the pipeline to send a notification on CI channel for this run.')
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7786

Example init commit: https://github.com/radtriste/optaplanner-quickstarts/commit/f4371d75d3aac614a6acf68f3ad45aa75ec91745

Related PRs:
- https://github.com/kiegroup/optaplanner/pull/2144
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/746
- https://github.com/kiegroup/optaplanner-quickstarts/pull/394

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
</details>
