### PR TITLE
PLANNER-2822 Correct Quarkus checks and add mandrel LTS check

### DIFF
--- a/.ci/jenkins/Jenkinsfile.specific_nightly
+++ b/.ci/jenkins/Jenkinsfile.specific_nightly
@@ -7,7 +7,7 @@ quickstartsRepo = 'optaplanner-quickstarts'
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem16g && !master'
+        label 'kie-rhel7 && kie-mem16g && !built-in'
     }
     tools {
         maven env.BUILD_MAVEN_TOOL
@@ -49,7 +49,7 @@ pipeline {
                     // Update downstream repositories dependencies
                     mavenCompareQuarkusDependencies(optaplannerRepo, 'optaplanner-build-parent')
                     mavenSetProperty(optaplannerRepo, 'version.io.quarkus', '999-SNAPSHOT')
-                    mavenCompareQuarkusDependencies(quickstarts)
+                    mavenCompareQuarkusDependencies(quickstartsRepo)
                     mavenSetProperty(quickstartsRepo, 'version.io.quarkus', '999-SNAPSHOT')
                 }
             }
@@ -115,22 +115,19 @@ pipeline {
 }
 
 void sendNotification() {
-    String additionalInfo = "**[${getBuildBranch()}] Optaplanner Quickstarts${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}**"
+    String additionalInfo = "**[${getQuickstartsBranch()}] Optaplanner Quickstarts${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}**"
     mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 
 void checkoutOptaplannerRepo() {
     dir(optaplannerRepo) {
-        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getBuildBranch(), false))
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getOptaplannerBranch(), false))
     }
 }
 
 void checkoutOptaplannerQuickstartsRepo() {
-    // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
-    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getBuildBranch()
-
     dir(quickstartsRepo) {
-        checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
+        checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, getQuickstartsBranch(), false))
     }
 }
 
@@ -172,7 +169,7 @@ MavenCommand getFullMavenCommand(String directory) {
     return mvnCmd
 }
 
-void mavenCompareQuarkusDependencies(String repo, String artifactId) {
+void mavenCompareQuarkusDependencies(String repo, String artifactId = '') {
     maven.mvnCompareDependencies(getBasicMavenCommand(repo), 'io.quarkus:quarkus-bom:999-SNAPSHOT', artifactId ? ":${artifactId}" : '', true, true)
 }
 
@@ -196,6 +193,10 @@ String getQuarkusBranch() {
     return env['QUARKUS_BRANCH'] ?: ''
 }
 
-String getBuildBranch() {
+String getQuickstartsBranch() {
     return params.BUILD_BRANCH_NAME
+}
+
+String getOptaplannerBranch() {
+    return getQuickstartsBranch() == 'development' ? 'main' : getQuickstartsBranch()
 }

--- a/.ci/jenkins/Jenkinsfile.specific_nightly
+++ b/.ci/jenkins/Jenkinsfile.specific_nightly
@@ -115,7 +115,8 @@ pipeline {
 }
 
 void sendNotification() {
-    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${getBuildBranch()}] OptaPlanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+    String additionalInfo = "**[${getBuildBranch()}] Optaplanner Quickstarts${NOTIFICATION_JOB_NAME ? " - ${NOTIFICATION_JOB_NAME}" : ''}**"
+    mailer.sendMarkdownTestSummaryNotification("CI failures", [env.OPTAPLANNER_CI_EMAIL_TO], additionalInfo)
 }
 
 void checkoutOptaplannerRepo() {

--- a/.ci/jenkins/Jenkinsfile.specific_nightly
+++ b/.ci/jenkins/Jenkinsfile.specific_nightly
@@ -1,0 +1,200 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+optaplannerRepo = 'optaplanner'
+quickstartsRepo = 'optaplanner-quickstarts'
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && kie-mem16g && !master'
+    }
+    tools {
+        maven env.BUILD_MAVEN_TOOL
+        jdk env.BUILD_JDK_TOOL
+    }
+    options {
+        timestamps()
+        timeout(time: 360, unit: 'MINUTES')
+    }
+    environment {
+        // QUARKUS_BRANCH should be defined directly into the job environment
+
+        OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+
+        MAVEN_OPTS = '-Xms1024m -Xmx4g'
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    checkoutQuarkusRepo()
+                    checkoutOptaplannerRepo()
+                    checkoutOptaplannerQuickstartsRepo()
+                }
+            }
+        }
+
+        stage('Build quarkus') {
+            when {
+                expression { getQuarkusBranch() }
+            }
+            steps {
+                script {
+                    checkoutQuarkusRepo()
+                    getBasicMavenCommand('quarkus')
+                        .withProperty('quickly')
+                        .run('clean install')
+
+                    // Update downstream repositories dependencies
+                    mavenCompareQuarkusDependencies(optaplannerRepo, 'optaplanner-build-parent')
+                    mavenSetProperty(optaplannerRepo, 'version.io.quarkus', '999-SNAPSHOT')
+                    mavenCompareQuarkusDependencies(quickstarts)
+                    mavenSetProperty(quickstartsRepo, 'version.io.quarkus', '999-SNAPSHOT')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+
+        stage('Build OptaPlanner') {
+            steps {
+                script {
+                    getEcosystemMavenCommand(optaplannerRepo)
+                        .withProperty('quickly')
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+
+        stage('Build Quickstarts') {
+            steps {
+                script {
+                    getFullMavenCommand(quickstartsRepo)
+                        .withProperty('maven.test.failure.ignore', true)
+                        .run('clean install')
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanContainers()
+                    }
+                }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendNotification()
+        }
+        always {
+            script {
+                junit testResults: '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml', allowEmptyResults: true
+                util.archiveConsoleLog()
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
+            }
+        }
+    }
+}
+
+void sendNotification() {
+    mailer.sendMarkdownTestSummaryNotification("${NOTIFICATION_JOB_NAME}", "[${getBuildBranch()}] OptaPlanner", [env.OPTAPLANNER_CI_EMAIL_TO])
+}
+
+void checkoutOptaplannerRepo() {
+    dir(optaplannerRepo) {
+        checkout(githubscm.resolveRepository(optaplannerRepo, params.GIT_AUTHOR, getBuildBranch(), false))
+    }
+}
+
+void checkoutOptaplannerQuickstartsRepo() {
+    // If the PR to OptaPlanner targets the 'main' branch, we assume the branch 'development' for quickstarts.
+    String quickstartsChangeTarget = params.BUILD_BRANCH_NAME == 'main' ? 'development' : getBuildBranch()
+
+    dir(quickstartsRepo) {
+        checkout(githubscm.resolveRepository(quickstartsRepo, params.GIT_AUTHOR, quickstartsChangeTarget, false))
+    }
+}
+
+void checkoutQuarkusRepo() {
+    dir('quarkus') {
+        checkout(githubscm.resolveRepository('quarkus', 'quarkusio', getQuarkusBranch(), false))
+    }
+}
+
+MavenCommand getBasicMavenCommand(String directory) {
+    return new MavenCommand(this, ['-fae', '-ntp'])
+                .withSettingsXmlId('kogito_release_settings')
+                .inDirectory(directory)
+}
+
+MavenCommand getEcosystemMavenCommand(String directory) {
+    def mvnCmd = getBasicMavenCommand(directory)
+
+    if (env.BUILD_MVN_OPTS) {
+        mvnCmd.withOptions([ env.BUILD_MVN_OPTS ])
+    }
+
+    return mvnCmd
+}
+
+MavenCommand getFullMavenCommand(String directory) {
+    def mvnCmd = getEcosystemMavenCommand(directory)
+    if (isNative()) {
+        mvnCmd.withProfiles(['native'])
+                .withProperty('quarkus.native.container-build', true)
+                .withProperty('quarkus.native.container-runtime', 'docker')
+                .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
+
+        String builderImage = getNativeBuilderImage()
+        if (builderImage) {
+            mvnCmd.withProperty('quarkus.native.builder-image', builderImage)
+        }
+    }
+    return mvnCmd
+}
+
+void mavenCompareQuarkusDependencies(String repo, String artifactId) {
+    maven.mvnCompareDependencies(getBasicMavenCommand(repo), 'io.quarkus:quarkus-bom:999-SNAPSHOT', artifactId ? ":${artifactId}" : '', true, true)
+}
+
+void mavenSetProperty(String repo, String property, String newVersion) {
+    maven.mvnSetVersionProperty(getBasicMavenCommand(repo), property, newVersion)
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
+}
+
+boolean isNative() {
+    return env.NATIVE ? env.NATIVE.toBoolean() : false
+}
+
+String getNativeBuilderImage() {
+    return env.NATIVE_BUILDER_IMAGE
+}
+
+String getQuarkusBranch() {
+    return env['QUARKUS_BRANCH'] ?: ''
+}
+
+String getBuildBranch() {
+    return params.BUILD_BRANCH_NAME
+}

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -62,7 +62,7 @@ KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'optaplanner-quickstarts', [
 
 void setupSpecificNightlyJob(Folder specificNightlyFolder) {
     String envName = specificNightlyFolder.environment.toName()
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner', specificNightlyFolder, "${jenkins_path}/Jenkinsfile.specific_nightly", "OptaPlanner Nightly ${envName}")
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'optaplanner-quickstarts', specificNightlyFolder, "${jenkins_path}/Jenkinsfile.specific_nightly", "OptaPlanner Nightly ${envName}")
     KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.triggers = [ cron : '@midnight' ]
     jobParams.env.putAll([

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,6 +57,14 @@ How to retest this PR or trigger a specific build:
   Run checks against Quarkus main branch  
   Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>
 
+- for <b>quarkus lts checks</b>  
+  Run checks against Quarkus lts branch  
+  Please add comment: <b>Jenkins run quarkus-lts</b>
+
+- for a <b>specific quarkus lts check</b>  
+  Run checks against Quarkus lts branch  
+  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>
+
 - for <b>native checks</b>  
   Run native checks  
   Please add comment: <b>Jenkins run native</b>
@@ -72,4 +80,12 @@ How to retest this PR or trigger a specific build:
 - for a <b>specific mandrel check</b>  
   Run native checks against Mandrel image  
   Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
+
+- for <b>mandrel lts checks</b>  
+  Run native checks against Mandrel image and quarkus lts branch
+  Please add comment: <b>Jenkins run mandrel-lts</b>
+
+- for a <b>specific mandrel lts check</b>  
+  Run native checks against Mandrel image and quarkus lts branch
+  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
 </details>


### PR DESCRIPTION
- setup unique specific nightly jenkinsfile to avoid repetition
- each repository is tested separately
- added Mandrel LTS check

### JIRA

https://issues.redhat.com/browse/PLANNER-2822

### Referenced pull requests

- https://github.com/kiegroup/optaplanner/pull/2217
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/759
- https://github.com/kiegroup/optaplanner-quickstarts/pull/413
- https://github.com/kiegroup/kogito-pipelines/pull/641

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
</details>
