### PR TITLE
PLANNER-2765 Expose the deployment template

### DIFF
--- a/technology/kubernetes/README.adoc
+++ b/technology/kubernetes/README.adoc
@@ -122,7 +122,7 @@ In this case, the `Solver` custom resource might look like follows:
 
 [source, yaml, linenums]
 ----
-apiVersion: org.optaplanner.solver/v1beta1
+apiVersion: org.optaplanner.solver/v1alpha1
 kind: Solver
 metadata:
   name: school-timetabling
@@ -137,7 +137,11 @@ spec:
     passwordSecretRef:
       key: AMQ_PASSWORD
       name: ex-aao-credentials-secret
-  solverImage: quay.io/example/school-timetabling:latest
+  template:
+    spec:
+      containers:
+        - name: school-timetabling
+          image: quay.io/example/school-timetabling:latest
   scaling:
     dynamic: true
     replicas: 3
@@ -147,9 +151,9 @@ spec:
 * lines 7 and 8 - ActiveMQ broker host and port accepting AMQP connections
 * line 9 - ActiveMQ broker host providing management interface
 * lines 10 to 15 - reference to a secret containing a username and password to access the broker
-* line 16 - the school-timetabling container image <<#buildSolverImage, built and pushed>> to a registry of your choice
-* line 18 - enables dynamic scaling via KEDA
-* line 19 - the maximum number of running school-timetabling pods; if dynamic scaling is disabled, this parameter defines a fixed number of pods
+* line 16 to 20 - the school-timetabling container that will run from the image <<#buildSolverImage, built and pushed>> to a registry of your choice
+* line 22 - enables dynamic scaling via KEDA
+* line 23 - the maximum number of running school-timetabling pods; if dynamic scaling is disabled, this parameter defines a fixed number of pods
 
 To find out the ActiveMQ broker management host:
 


### PR DESCRIPTION
Updates a readme to reflect changes in https://github.com/kiegroup/optaplanner/pull/2225/.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2765

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests
- https://github.com/kiegroup/optaplanner/pull/2225
- https://github.com/kiegroup/optaplanner-quickstarts/pull/420

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
</details>
