### PR TITLE
Call center use solver manager

### DIFF
--- a/use-cases/call-center/src/main/java/org/acme/callcenter/rest/CallCenterResource.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/rest/CallCenterResource.java
@@ -45,9 +45,9 @@ public class CallCenterResource {
     @POST
     @Path("solve")
     public void solve() {
-        solverService.startSolving(bestSolution.get(), bestSolutionChangedEvent -> {
-            bestSolution.set(bestSolutionChangedEvent.getNewBestSolution());
-            simulationService.onNewBestSolution(bestSolutionChangedEvent.getNewBestSolution());
+        solverService.startSolving(bestSolution.get(), newBestSolution -> {
+            bestSolution.set(newBestSolution);
+            simulationService.onNewBestSolution(newBestSolution);
         }, throwable -> solvingError.set(throwable));
         simulationService.startSimulation();
     }

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
@@ -59,7 +59,7 @@ public class SolverService {
     }
 
     public boolean isSolving() {
-        return solverManager.getSolverStatus(SINGLETON_ID) == SolverStatus.SOLVING_ACTIVE;
+        return solverManager.getSolverStatus(SINGLETON_ID) != SolverStatus.NOT_SOLVING;
     }
 
     public void addCall(Call call) {

--- a/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/service/SolverService.java
@@ -6,7 +6,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import org.acme.callcenter.domain.Agent;
@@ -16,7 +15,6 @@ import org.acme.callcenter.solver.change.AddCallProblemChange;
 import org.acme.callcenter.solver.change.PinCallProblemChange;
 import org.acme.callcenter.solver.change.ProlongCallByMinuteProblemChange;
 import org.acme.callcenter.solver.change.RemoveCallProblemChange;
-import org.eclipse.microprofile.context.ManagedExecutor;
 import org.optaplanner.core.api.solver.SolverManager;
 import org.optaplanner.core.api.solver.SolverStatus;
 import org.optaplanner.core.api.solver.change.ProblemChange;
@@ -25,7 +23,7 @@ import org.optaplanner.core.api.solver.change.ProblemChange;
 public class SolverService {
 
     private final SolverManager<CallCenter, Long> solverManager;
-    private final long SINGLETON_ID = 1L;
+    public static final long SINGLETON_ID = 1L;
 
     private final BlockingQueue<ProblemChange<CallCenter>> waitingProblemChanges = new LinkedBlockingQueue<>();
 
@@ -44,10 +42,10 @@ public class SolverService {
     }
 
     public void startSolving(CallCenter inputProblem,
-            Consumer<CallCenter> bestSolutionChangedEventConsumer, Consumer<Throwable> errorHandler) {
+            Consumer<CallCenter> bestSolutionConsumer, Consumer<Throwable> errorHandler) {
         solverManager.solveAndListen(SINGLETON_ID, id -> inputProblem, bestSolution -> {
                                          if (bestSolution.getScore().isSolutionInitialized()) {
-                                             bestSolutionChangedEventConsumer.accept(bestSolution);
+                                             bestSolutionConsumer.accept(bestSolution);
                                              pinCallAssignedToAgents(bestSolution.getCalls());
                                          }
                                      },

--- a/use-cases/call-center/src/test/java/org/acme/callcenter/solver/SolverServiceTest.java
+++ b/use-cases/call-center/src/test/java/org/acme/callcenter/solver/SolverServiceTest.java
@@ -14,6 +14,7 @@ import org.acme.callcenter.domain.Call;
 import org.acme.callcenter.domain.CallCenter;
 import org.acme.callcenter.domain.Skill;
 import org.acme.callcenter.service.SolverService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Timeout;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.core.api.solver.SolverStatus;
 
 @QuarkusTest
 public class SolverServiceTest {
@@ -36,6 +38,13 @@ public class SolverServiceTest {
     @BeforeEach
     void setUp() {
         solverService = new SolverService(solverManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (solverManager.getSolverStatus(SolverService.SINGLETON_ID) != SolverStatus.NOT_SOLVING) {
+            solverManager.terminateEarly(SolverService.SINGLETON_ID);
+        }
     }
 
     @Test

--- a/use-cases/call-center/src/test/java/org/acme/callcenter/solver/SolverServiceTest.java
+++ b/use-cases/call-center/src/test/java/org/acme/callcenter/solver/SolverServiceTest.java
@@ -115,16 +115,16 @@ public class SolverServiceTest {
 
         AtomicReference<Throwable> errorDuringSolving = new AtomicReference<>();
         AtomicReference<CallCenter> bestSolution = new AtomicReference<>();
-        solverService.startSolving(inputProblem, newBestSolution -> {
-            bestSolution.set(newBestSolution);
-            allChangesProcessed.countDown();
-            solverService.stopSolving();
-        }, throwable -> errorDuringSolving.set(throwable));
+        solverService.startSolving(inputProblem, bestSolution::set, errorDuringSolving::set);
 
         problemChanges.run();
+        solverManager.addProblemChange(SolverService.SINGLETON_ID, (workingSolution, problemChangeDirector) -> {
+            bestSolution.set(null); // ignore previous best solution since all changes were not process yet
+            allChangesProcessed.countDown();
+        });
 
         try {
-            while (!allChangesProcessed.await(10, TimeUnit.MILLISECONDS)) {
+            while (!allChangesProcessed.await(10, TimeUnit.MILLISECONDS) || bestSolution.get() == null) {
                 if (errorDuringSolving.get() != null) {
                     throw new IllegalStateException("Exception during solving", errorDuringSolving.get());
                 }
@@ -132,7 +132,7 @@ public class SolverServiceTest {
         } catch (InterruptedException interruptedException) {
             throw new IllegalStateException("Interrupted during waiting.", interruptedException);
         }
-
+        solverService.stopSolving();
         return bestSolution.get();
     }
 


### PR DESCRIPTION
Replaces https://github.com/kiegroup/optaplanner-quickstarts/pull/304.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
</details>
