### PR TITLE
Fix the Gradle build

### DIFF
--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,11 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.13.2.Final"
+    // TODO: upgrade the Quarkus version after https://github.com/quarkusio/quarkus/issues/28591 is fixed
+    id "io.quarkus" version "2.13.0.Final"
 }
 
-def quarkusVersion = "2.13.2.Final"
+// TODO: upgrade the Quarkus version after https://github.com/quarkusio/quarkus/issues/28591 is fixed
+def quarkusVersion = "2.13.0.Final"
 def optaplannerVersion = "8.30.0-SNAPSHOT"
 
 group = "org.acme"


### PR DESCRIPTION
Fixes the Gradle CI failure introduced by https://github.com/kiegroup/optaplanner-quickstarts/pull/426.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
</details>
