### PR TITLE
PLANNER-2783 Replace momentjs by js-joda

### DIFF
--- a/technology/java-activemq-quarkus/client/pom.xml
+++ b/technology/java-activemq-quarkus/client/pom.xml
@@ -90,8 +90,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>momentjs</artifactId>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>js-joda</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/app.js
+++ b/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/app.js
@@ -1,4 +1,5 @@
 var autoRefreshIntervalId = null;
+const dateTimeFormatter = JSJoda.DateTimeFormatter.ofPattern('HH:mm')
 
 function refreshTimeTable() {
   $.getJSON("/timeTable", function (timeTable) {
@@ -47,15 +48,18 @@ function refreshTimeTable() {
     const tbodyByRoom = $("<tbody>").appendTo(timeTableByRoom);
     const tbodyByTeacher = $("<tbody>").appendTo(timeTableByTeacher);
     const tbodyByStudentGroup = $("<tbody>").appendTo(timeTableByStudentGroup);
+
+    const LocalTime = JSJoda.LocalTime;
+
     $.each(timeTable.timeslotList, (index, timeslot) => {
       const rowByRoom = $("<tr>").appendTo(tbodyByRoom);
       rowByRoom
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)
             .append($(`<button type="button" class="ml-2 mb-1 btn btn-light btn-sm p-1"/>`)
               .append($(`<small class="fas fa-trash"/>`)
@@ -66,9 +70,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(timeTable.roomList, (index, room) => {
         rowByRoom.append($("<td/>").prop("id", `timeslot${timeslot.id}room${room.id}`));
@@ -78,9 +82,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
 
       $.each(teacherList, (index, teacher) => {

--- a/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/index.html
+++ b/technology/java-activemq-quarkus/client/src/main/resources/META-INF/resources/index.html
@@ -69,7 +69,7 @@
 
 <script src="/webjars/jquery/jquery.min.js"></script>
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
-<script src="/webjars/momentjs/min/moment.min.js"></script>
+<script src="/webjars/js-joda/dist/js-joda.min.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -85,9 +85,9 @@
         <version>5.15.1</version>
       </dependency>
       <dependency>
-        <groupId>org.webjars</groupId>
-        <artifactId>momentjs</artifactId>
-        <version>2.24.0</version>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>js-joda</artifactId>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     runtimeOnly "org.webjars:webjars-locator:0.37"
     runtimeOnly "org.webjars:bootstrap:4.3.1"
     runtimeOnly "org.webjars:font-awesome:5.11.2"
-    runtimeOnly "org.webjars:momentjs:2.24.0"
+    runtimeOnly "org.webjars.npm:js-joda:1.11.0"
 }
 
 test {

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -113,9 +113,9 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>momentjs</artifactId>
-      <version>2.24.0</version>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>js-joda</artifactId>
+      <version>1.11.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/technology/java-spring-boot/src/main/resources/static/app.js
+++ b/technology/java-spring-boot/src/main/resources/static/app.js
@@ -1,4 +1,5 @@
 var autoRefreshIntervalId = null;
+const dateTimeFormatter = JSJoda.DateTimeFormatter.ofPattern('HH:mm')
 
 function refreshTimeTable() {
   $.getJSON("/timeTable", function (timeTable) {
@@ -47,15 +48,18 @@ function refreshTimeTable() {
     const tbodyByRoom = $("<tbody>").appendTo(timeTableByRoom);
     const tbodyByTeacher = $("<tbody>").appendTo(timeTableByTeacher);
     const tbodyByStudentGroup = $("<tbody>").appendTo(timeTableByStudentGroup);
+
+    const LocalTime = JSJoda.LocalTime;
+
     $.each(timeTable.timeslotList, (index, timeslot) => {
       const rowByRoom = $("<tr>").appendTo(tbodyByRoom);
       rowByRoom
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)
             .append($(`<button type="button" class="ml-2 mb-1 btn btn-light btn-sm p-1"/>`)
               .append($(`<small class="fas fa-trash"/>`)
@@ -69,9 +73,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(teacherList, (index, teacher) => {
         rowByTeacher.append($("<td/>").prop("id", `timeslot${timeslot.id}teacher${convertToId(teacher)}`));
@@ -82,9 +86,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(studentGroupList, (index, studentGroup) => {
         rowByStudentGroup.append($("<td/>").prop("id", `timeslot${timeslot.id}studentGroup${convertToId(studentGroup)}`));

--- a/technology/java-spring-boot/src/main/resources/static/index.html
+++ b/technology/java-spring-boot/src/main/resources/static/index.html
@@ -173,7 +173,7 @@
 
 <script src="/webjars/jquery/jquery.min.js"></script>
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
-<script src="/webjars/momentjs/min/moment.min.js"></script>
+<script src="/webjars/js-joda/dist/js-joda.min.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -139,9 +139,9 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>momentjs</artifactId>
-      <version>2.24.0</version>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>js-joda</artifactId>
+      <version>1.11.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/technology/kotlin-quarkus/src/main/resources/META-INF/resources/app.js
+++ b/technology/kotlin-quarkus/src/main/resources/META-INF/resources/app.js
@@ -1,4 +1,5 @@
 var autoRefreshIntervalId = null;
+const dateTimeFormatter = JSJoda.DateTimeFormatter.ofPattern('HH:mm')
 
 function refreshTimeTable() {
   $.getJSON("/timeTable", function (timeTable) {
@@ -47,15 +48,18 @@ function refreshTimeTable() {
     const tbodyByRoom = $("<tbody>").appendTo(timeTableByRoom);
     const tbodyByTeacher = $("<tbody>").appendTo(timeTableByTeacher);
     const tbodyByStudentGroup = $("<tbody>").appendTo(timeTableByStudentGroup);
+
+    const LocalTime = JSJoda.LocalTime;
+
     $.each(timeTable.timeslotList, (index, timeslot) => {
       const rowByRoom = $("<tr>").appendTo(tbodyByRoom);
       rowByRoom
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)
             .append($(`<button type="button" class="ml-2 mb-1 btn btn-light btn-sm p-1"/>`)
               .append($(`<small class="fas fa-trash"/>`)
@@ -69,9 +73,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(teacherList, (index, teacher) => {
         rowByTeacher.append($("<td/>").prop("id", `timeslot${timeslot.id}teacher${convertToId(teacher)}`));
@@ -82,9 +86,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(studentGroupList, (index, studentGroup) => {
         rowByStudentGroup.append($("<td/>").prop("id", `timeslot${timeslot.id}studentGroup${convertToId(studentGroup)}`));

--- a/technology/kotlin-quarkus/src/main/resources/META-INF/resources/index.html
+++ b/technology/kotlin-quarkus/src/main/resources/META-INF/resources/index.html
@@ -172,7 +172,7 @@
 
 <script src="/webjars/jquery/jquery.min.js"></script>
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
-<script src="/webjars/momentjs/min/moment.min.js"></script>
+<script src="/webjars/js-joda/dist/js-joda.min.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/technology/kubernetes/demo-app/pom.xml
+++ b/technology/kubernetes/demo-app/pom.xml
@@ -86,11 +86,6 @@
       <artifactId>font-awesome</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>momentjs</artifactId>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/technology/kubernetes/demo-app/src/main/resources/META-INF/resources/index.html
+++ b/technology/kubernetes/demo-app/src/main/resources/META-INF/resources/index.html
@@ -45,7 +45,6 @@
 </div>
 <script src="/webjars/jquery/jquery.min.js"></script>
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
-<script src="/webjars/momentjs/min/moment.min.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -82,11 +82,6 @@
         <artifactId>font-awesome</artifactId>
         <version>5.15.1</version>
       </dependency>
-      <dependency>
-        <groupId>org.webjars</groupId>
-        <artifactId>momentjs</artifactId>
-        <version>2.24.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     runtimeOnly "org.webjars:bootstrap:4.3.1"
     runtimeOnly "org.webjars:jquery:3.4.1"
     runtimeOnly "org.webjars:font-awesome:5.11.2"
-    runtimeOnly "org.webjars:momentjs:2.24.0"
+    runtimeOnly "org.webjars.npm:js-joda:1.11.0"
 
 }
 

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -125,9 +125,9 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.webjars</groupId>
-      <artifactId>momentjs</artifactId>
-      <version>2.24.0</version>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>js-joda</artifactId>
+      <version>1.11.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/use-cases/school-timetabling/src/main/resources/META-INF/resources/app.js
+++ b/use-cases/school-timetabling/src/main/resources/META-INF/resources/app.js
@@ -1,4 +1,5 @@
 var autoRefreshIntervalId = null;
+const dateTimeFormatter = JSJoda.DateTimeFormatter.ofPattern('HH:mm')
 
 $(document).ready(function () {
   $.ajaxSetup({
@@ -94,15 +95,18 @@ function refreshTimeTable() {
     const tbodyByRoom = $("<tbody>").appendTo(timeTableByRoom);
     const tbodyByTeacher = $("<tbody>").appendTo(timeTableByTeacher);
     const tbodyByStudentGroup = $("<tbody>").appendTo(timeTableByStudentGroup);
+
+    const LocalTime = JSJoda.LocalTime;
+
     $.each(timeTable.timeslotList, (index, timeslot) => {
       const rowByRoom = $("<tr>").appendTo(tbodyByRoom);
       rowByRoom
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)
             .append($(`<button type="button" class="ml-2 mb-1 btn btn-light btn-sm p-1"/>`)
               .append($(`<small class="fas fa-trash"/>`)
@@ -116,9 +120,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(teacherList, (index, teacher) => {
         rowByTeacher.append($("<td/>").prop("id", `timeslot${timeslot.id}teacher${convertToId(teacher)}`));
@@ -129,9 +133,9 @@ function refreshTimeTable() {
         .append($(`<th class="align-middle"/>`)
           .append($("<span/>").text(`
                     ${timeslot.dayOfWeek.charAt(0) + timeslot.dayOfWeek.slice(1).toLowerCase()}
-                    ${moment(timeslot.startTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.startTime).format(dateTimeFormatter)}
                     -
-                    ${moment(timeslot.endTime, "HH:mm:ss").format("HH:mm")}
+                    ${LocalTime.parse(timeslot.endTime).format(dateTimeFormatter)}
                 `)));
       $.each(studentGroupList, (index, studentGroup) => {
         rowByStudentGroup.append($("<td/>").prop("id", `timeslot${timeslot.id}studentGroup${convertToId(studentGroup)}`));

--- a/use-cases/school-timetabling/src/main/resources/META-INF/resources/index.html
+++ b/use-cases/school-timetabling/src/main/resources/META-INF/resources/index.html
@@ -172,7 +172,7 @@
 
 <script src="/webjars/jquery/jquery.min.js"></script>
 <script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
-<script src="/webjars/momentjs/min/moment.min.js"></script>
+<script src="/webjars/js-joda/dist/js-joda.min.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This is only a partial replacement; the vaccination scheduling quickstart is missing. The vaccination scheduling uses DateTime formatting supported by localized `js-joda` plugins. Unfortunately, these plugins are not available in webjars.

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA
https://issues.redhat.com/browse/PLANNER-2783

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>
