### PR TITLE
Fix copy-paste issue

### DIFF
--- a/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
+++ b/use-cases/call-center/src/main/java/org/acme/callcenter/data/DataGenerator.java
@@ -54,7 +54,7 @@ public class DataGenerator {
     }
 
     private synchronized Skill pickRandomLanguageSkill() {
-        return LANGUAGE_SKILLS[RANDOM.nextInt(PRODUCT_SKILLS.length)];
+        return LANGUAGE_SKILLS[RANDOM.nextInt(LANGUAGE_SKILLS.length)];
     }
 
     private synchronized String generatePhoneNumber() {


### PR DESCRIPTION
pickRandomLanguageSkill should use LANGUAGE_SKILLS.length and not PRODUCT_SKILLS.length. Currently this still works as both LANGUAGE_SKILLS and PRODUCT_SKILLS have the same length of 3, but in the future this might change and cause an error.

