### PR TITLE
Bump Artemis to 2.24.0

### DIFF
--- a/technology/java-activemq-quarkus/docker-compose.yml
+++ b/technology/java-activemq-quarkus/docker-compose.yml
@@ -5,7 +5,7 @@ version: '2'
 services:
 
   artemis:
-    image: vromero/activemq-artemis:2.15.0-alpine
+    image: quay.io/artemiscloud/activemq-artemis-broker:latest
     ports:
       - "8161:8161"
       - "61616:61616"
@@ -13,6 +13,6 @@ services:
     volumes:
       - .:/var/lib/artemis/etc-override
     environment:
-      ARTEMIS_USERNAME: quarkus
-      ARTEMIS_PASSWORD: quarkus
+      AMQ_USER: quarkus
+      AMQ_PASSWORD: quarkus
 

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -10,7 +10,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <version.org.apache.activemq>2.19.0</version.org.apache.activemq>
+    <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
     <version.io.quarkus>2.14.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.31.0-SNAPSHOT</version.org.optaplanner>
 

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.apache.activemq>2.19.0</version.org.apache.activemq>
+    <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
     <version.io.quarkus>2.14.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.31.0-SNAPSHOT</version.org.optaplanner>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
Replaces #401 and #398 and unifies the Artemis docker image. 

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>
