### PR TITLE
[BXMSPROD-1881] dependabot for release and blue branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '03:00'
+  open-pull-requests-limit: 10
+  target-branch: "development"
+  commit-message:
+    prefix: "[bot][dev]"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '04:00'
+  open-pull-requests-limit: 10
+  target-branch: "8.13.x"
+  commit-message:
+    prefix: "[bot][8.13.x]"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '05:00'
+  open-pull-requests-limit: 10
+  target-branch: "8.13.x-blue"
+  commit-message:
+    prefix: "[bot][blue]"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '06:00'
+  open-pull-requests-limit: 10
+  target-branch: "8.29.x"
+  commit-message:
+    prefix: "[bot][8.29.x]"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,24 +18,6 @@ updates:
   target-branch: "8.13.x"
   commit-message:
     prefix: "[bot][8.13.x]"
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '05:00'
-  open-pull-requests-limit: 10
-  target-branch: "8.13.x-blue"
-  commit-message:
-    prefix: "[bot][blue]"
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '06:00'
-  open-pull-requests-limit: 10
-  target-branch: "8.29.x"
-  commit-message:
-    prefix: "[bot][8.29.x]"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: '03:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "development"
   commit-message:
     prefix: "[bot][dev]"
@@ -14,7 +14,7 @@ updates:
   schedule:
     interval: daily
     time: '04:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "8.13.x"
   commit-message:
     prefix: "[bot][8.13.x]"


### PR DESCRIPTION
related PRs:

* https://github.com/kiegroup/optaplanner-quickstarts/pull/459
* https://github.com/kiegroup/kogito-apps/pull/1512
* https://github.com/kiegroup/kogito-runtimes/pull/2624
* https://github.com/kiegroup/kogito-examples/pull/1485

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>
