### PR TITLE
PLANNER-2868 Move build-chain config

### DIFF
--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -52,7 +52,7 @@ jobs:
         id: build-chain
         uses: kiegroup/github-action-build-chain@v2.6.8
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/kogito-pipelines/main/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/optaplanner/main/.ci/buildchain-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: "-Dfull"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build Chain
         uses: kiegroup/kogito-pipelines/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/%{process.env.GITHUB_BASE_REF.replace(/(\d*)\.(.*)\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`).replace('development', 'main')}/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Surefire Report


### PR DESCRIPTION
to main optaplanner repository

https://issues.redhat.com/browse/PLANNER-2868

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/720
- https://github.com/kiegroup/optaplanner/pull/2388
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/821
- https://github.com/kiegroup/optaplanner-quickstarts/pull/462