### PR TITLE
Upgrade to Spring Boot 3.x

### DIFF
--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -8,11 +8,11 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
-    <version.org.springframework.boot>2.7.4</version.org.springframework.boot>
+    <version.org.springframework.boot>3.0.1</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -1,9 +1,9 @@
 package org.acme.schooltimetabling.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.lookup.PlanningId;

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Room.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Room.java
@@ -1,8 +1,8 @@
 package org.acme.schooltimetabling.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 import org.optaplanner.core.api.domain.lookup.PlanningId;
 

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Timeslot.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/domain/Timeslot.java
@@ -3,9 +3,9 @@ package org.acme.schooltimetabling.domain;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 import org.optaplanner.core.api.domain.lookup.PlanningId;
 

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/LessonRepository.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/LessonRepository.java
@@ -2,11 +2,12 @@ package org.acme.schooltimetabling.persistence;
 
 import java.util.List;
 
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import org.acme.schooltimetabling.domain.Lesson;
 
-public interface LessonRepository extends PagingAndSortingRepository<Lesson, Long> {
+public interface LessonRepository extends CrudRepository<Lesson, Long>, PagingAndSortingRepository<Lesson, Long> {
 
     @Override
     List<Lesson> findAll();

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/RoomRepository.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/RoomRepository.java
@@ -2,11 +2,12 @@ package org.acme.schooltimetabling.persistence;
 
 import java.util.List;
 
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import org.acme.schooltimetabling.domain.Room;
 
-public interface RoomRepository extends PagingAndSortingRepository<Room, Long> {
+public interface RoomRepository extends CrudRepository<Room, Long>, PagingAndSortingRepository<Room, Long> {
 
     @Override
     List<Room> findAll();

--- a/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/TimeslotRepository.java
+++ b/technology/java-spring-boot/src/main/java/org/acme/schooltimetabling/persistence/TimeslotRepository.java
@@ -2,11 +2,12 @@ package org.acme.schooltimetabling.persistence;
 
 import java.util.List;
 
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import org.acme.schooltimetabling.domain.Timeslot;
 
-public interface TimeslotRepository extends PagingAndSortingRepository<Timeslot, Long> {
+public interface TimeslotRepository extends CrudRepository<Timeslot, Long>, PagingAndSortingRepository<Timeslot, Long> {
 
     @Override
     List<Timeslot> findAll();


### PR DESCRIPTION
- PagingAndSortingRepository no longer extends CrudRepository, so now our Repositories need to extend both PagingAndSortingRepository and CrudRepository to get the same functionality/methods.

- Migrated from javax to jakarta

- Spring Boot 3.x only support Java 17, so upgraded the release version

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>
