### PR TITLE
Update dependencies to match latest optaplanner-test

### DIFF
--- a/hello-world/build.gradle
+++ b/hello-world/build.gradle
@@ -6,6 +6,7 @@ plugins {
 def optaplannerVersion = "8.34.0-SNAPSHOT"
 def logbackVersion = "1.2.11"
 def junitJupiterVersion = "5.9.0"
+def assertjVersion = "3.24.2"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"
@@ -26,6 +27,7 @@ dependencies {
     implementation "org.optaplanner:optaplanner-core"
     testImplementation "org.optaplanner:optaplanner-test"
     testImplementation "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 
     runtimeOnly "ch.qos.logback:logback-classic:${logbackVersion}"
 }

--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -13,11 +13,12 @@
     <jar.with.dependencies.name>hello-world-run</jar.with.dependencies.name>
 
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.assertj>3.24.2</version.org.assertj>
     <version.org.junit.jupiter>5.9.0</version.org.junit.jupiter>
     <version.org.logback>1.2.11</version.org.logback>
 
     <version.compiler.plugin>3.10.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
     <version.assembly.plugin>3.4.2</version.assembly.plugin>
   </properties>
 
@@ -65,6 +66,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.org.assertj}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -17,7 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
   </properties>
 
   <modules>
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.20.2</version>
+        <version>3.24.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 def optaplannerVersion = "8.34.0-SNAPSHOT"
+def assertjVersion = "3.24.2"
 
 group = "org.acme"
 archivesBaseName = "optaplanner-spring-boot-school-timetabling-quickstart"
@@ -34,6 +35,7 @@ dependencies {
     implementation "org.optaplanner:optaplanner-spring-boot-starter"
     testImplementation("org.optaplanner:optaplanner-test")
     testImplementation("org.optaplanner:optaplanner-benchmark")
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 
     runtimeOnly "com.h2database:h2"
     runtimeOnly "org.webjars:webjars-locator:0.37"

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -15,7 +15,7 @@
     <version.org.springframework.boot>2.7.4</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -16,7 +16,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.jandex.plugin>1.0.8</version.jandex.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.23.1</version>
+        <version>3.24.2</version>
       </dependency>
       <dependency>
         <groupId>org.webjars</groupId>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -79,6 +79,12 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -100,6 +100,12 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 def quarkusVersion = "2.16.0.Final"
 def optaplannerVersion = "8.34.0-SNAPSHOT"
+def assertjVersion = "3.24.2"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"
@@ -38,6 +39,7 @@ dependencies {
     implementation "org.optaplanner:optaplanner-quarkus-jackson"
     testImplementation "org.optaplanner:optaplanner-test"
     testImplementation "org.optaplanner:optaplanner-quarkus-benchmark"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 
     runtimeOnly "org.webjars:bootstrap:4.3.1"
     runtimeOnly "org.webjars:jquery:3.4.1"

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
     
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -15,7 +15,7 @@
     <version.org.optaplanner>8.34.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>
@@ -76,6 +76,12 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
