### PR TITLE
[KOGITO-8377]: Merged native and mandrel checks

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -49,8 +49,7 @@ setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_NATIVE)
 setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_QUARKUS_MAIN)
 setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_QUARKUS_BRANCH)
 
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_MANDREL)
-setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_MANDREL_LTS)
+setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_NATIVE_LTS)
 setupSpecificBuildChainNightlyJob(Folder.NIGHTLY_QUARKUS_LTS)
 
 // Tools

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -73,21 +73,13 @@ How to retest this PR or trigger a specific build:
   Run native checks 
   Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>
 
-- for <b>mandrel checks</b>  
-  Run native checks against Mandrel image
-  Please add comment: <b>Jenkins run mandrel</b>
+- for <b>native lts checks</b>  
+  Run native checks against quarkus lts branch
+  Please add comment: <b>Jenkins run native-lts</b>
 
-- for a <b>specific mandrel check</b>  
-  Run native checks against Mandrel image  
-  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>
-
-- for <b>mandrel lts checks</b>  
-  Run native checks against Mandrel image and quarkus lts branch
-  Please add comment: <b>Jenkins run mandrel-lts</b>
-
-- for a <b>specific mandrel lts check</b>  
-  Run native checks against Mandrel image and quarkus lts branch
-  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
+- for a <b>specific native lts check</b>  
+  Run native checks against quarkus lts branch
+  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native-lts</b>
 </details>
 
 <details>

--- a/build/optaplanner-distribution/pom.xml
+++ b/build/optaplanner-distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.33.0-SNAPSHOT</version>
+    <version>8.33.0.Final</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-quickstarts-parent</artifactId>
-    <version>8.33.0-SNAPSHOT</version>
+    <version>8.33.0.Final</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hello-world/build.gradle
+++ b/hello-world/build.gradle
@@ -13,12 +13,6 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-        url "https://repository.jboss.org/nexus/content/groups/public/"
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {

--- a/hello-world/build.gradle
+++ b/hello-world/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "application"
 }
 
-def optaplannerVersion = "8.33.0-SNAPSHOT"
+def optaplannerVersion = "8.33.0.Final"
 def logbackVersion = "1.2.11"
 def junitJupiterVersion = "5.9.0"
 

--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -126,17 +126,4 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jar.with.dependencies.name>hello-world-run</jar.with.dependencies.name>
 
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
     <version.org.junit.jupiter>5.9.0</version.org.junit.jupiter>
     <version.org.logback>1.2.11</version.org.logback>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,18 +57,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <!-- To get snapshots during development. Remove this in the "stable" branch (which doesn't use snapshots). -->
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.33.0-SNAPSHOT</version>
+    <version>8.33.0.Final</version>
     <relativePath/>
   </parent>
   <!-- IMPORTANT: the individual quickstarts have no parent pom. -->

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -172,17 +172,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "java"
 }
 
-def optaplannerVersion = "8.33.0-SNAPSHOT"
+def optaplannerVersion = "8.33.0.Final"
 
 group = "org.acme"
 archivesBaseName = "optaplanner-spring-boot-school-timetabling-quickstart"

--- a/technology/java-spring-boot/build.gradle
+++ b/technology/java-spring-boot/build.gradle
@@ -14,12 +14,6 @@ sourceCompatibility = "11"
 repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-        url "https://repository.jboss.org/nexus/content/groups/public/"
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -146,17 +146,4 @@
     </plugins>
   </build>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
     <version.org.springframework.boot>2.7.4</version.org.springframework.boot>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -276,17 +276,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.kotlin>1.6.21</version.kotlin>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -13,7 +13,7 @@
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.kotlin>1.6.21</version.kotlin>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -160,17 +160,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.jandex.plugin>1.0.8</version.jandex.plugin>

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -21,7 +21,7 @@
 
     <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.jandex.plugin>1.0.8</version.jandex.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -190,17 +190,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -213,17 +213,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -186,17 +186,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -213,17 +213,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -187,17 +187,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 def quarkusVersion = "2.16.0.Final"
-def optaplannerVersion = "8.33.0-SNAPSHOT"
+def optaplannerVersion = "8.33.0.Final"
 
 group = "org.acme"
 version = "1.0-SNAPSHOT"

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "2.15.0.Final"
+    id "io.quarkus" version "2.16.0.Final"
 }
 
-def quarkusVersion = "2.15.0.Final"
+def quarkusVersion = "2.16.0.Final"
 def optaplannerVersion = "8.33.0-SNAPSHOT"
 
 group = "org.acme"

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -12,12 +12,6 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-        url "https://repository.jboss.org/nexus/content/groups/public/"
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -221,17 +221,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
     
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
     
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -201,17 +201,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -201,17 +201,4 @@
     </profile>
   </profiles>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <!-- Get releases only from Maven Central which is faster. -->
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.quarkus>2.16.0.Final</version.io.quarkus>
-    <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
+    <version.org.optaplanner>8.33.0.Final</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>2.15.0.Final</version.io.quarkus>
+    <version.io.quarkus>2.16.0.Final</version.io.quarkus>
     <version.org.optaplanner>8.33.0-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

[KOGITO-8377](https://issues.redhat.com/browse/KOGITO-8377)

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->

- https://github.com/kiegroup/optaplanner/pull/2543
- https://github.com/kiegroup/optaplanner-quickstarts/pull/502
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/841
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
