### PR TITLE
Lambda Memory Leak

### DIFF
--- a/hello-world/run.sh
+++ b/hello-world/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+JDK_JAVA_OPTIONS="-XX:+UseParallelGC -Xlog:class+load=info:loadedClasses.txt" gradle run

--- a/hello-world/src/main/java/org/acme/schooltimetabling/TimeTableApp.java
+++ b/hello-world/src/main/java/org/acme/schooltimetabling/TimeTableApp.java
@@ -24,24 +24,28 @@ public class TimeTableApp {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TimeTableApp.class);
 
-    public static void main(String[] args) {
-        SolverFactory<TimeTable> solverFactory = SolverFactory.create(new SolverConfig()
-                .withSolutionClass(TimeTable.class)
-                .withEntityClasses(Lesson.class)
-                .withConstraintProviderClass(TimeTableConstraintProvider.class)
-                // The solver runs only for 5 seconds on this small dataset.
-                // It's recommended to run for at least 5 minutes ("5m") otherwise.
-                .withTerminationSpentLimit(Duration.ofSeconds(5)));
+    public static void main(String[] args) throws InterruptedException {
+        while(true) {
+            SolverFactory<TimeTable> solverFactory = SolverFactory.create(new SolverConfig()
+                    .withSolutionClass(TimeTable.class)
+                    .withEntityClasses(Lesson.class)
+                    .withConstraintProviderClass(TimeTableConstraintProvider.class)
+                    // The solver runs only for 5 seconds on this small dataset.
+                    // It's recommended to run for at least 5 minutes ("5m") otherwise.
+                    .withTerminationSpentLimit(Duration.ofSeconds(5)));
 
-        // Load the problem
-        TimeTable problem = generateDemoData();
+            // Load the problem
+            TimeTable problem = generateDemoData();
 
-        // Solve the problem
-        Solver<TimeTable> solver = solverFactory.buildSolver();
-        TimeTable solution = solver.solve(problem);
+            // Solve the problem
+            Solver<TimeTable> solver = solverFactory.buildSolver();
+            TimeTable solution = solver.solve(problem);
 
-        // Visualize the solution
-        printTimetable(solution);
+            Thread.sleep(1000);
+        }
+
+//        // Visualize the solution
+//        printTimetable(solution);
     }
 
     public static TimeTable generateDemoData() {

--- a/hello-world/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
+++ b/hello-world/src/main/java/org/acme/schooltimetabling/domain/Lesson.java
@@ -7,7 +7,6 @@ import org.optaplanner.core.api.domain.variable.PlanningVariable;
 @PlanningEntity
 public class Lesson {
 
-    @PlanningId
     private Long id;
 
     private String subject;
@@ -45,6 +44,7 @@ public class Lesson {
     // Getters and setters
     // ************************************************************************
 
+    @PlanningId
     public Long getId() {
         return id;
     }


### PR DESCRIPTION
Only changed `@PlanningID` Field->Method, and now leaks classes
```sh
# Run hello world (loops every second)
$ optaplanner-quickstarts/hello-world/run.sh

# Show loaded classes being loaded every second
$ tail -f loadedClasses.txt
```

```
$ tail -f loadedClasses.txt
[1.066s][info][class,load] org.optaplanner.core.impl.localsearch.scope.LocalSearchMoveScope source: file:/Users/teejae/.m2/repository/org/optaplanner/optaplanner-core-impl/8.35.0-SNAPSHOT/optaplanner-core-impl-8.35.0-SNAPSHOT.jar
[1.066s][info][class,load] org.optaplanner.core.impl.localsearch.decider.LocalSearchDecider$$Lambda$636/0x000000080044a320 source: org.optaplanner.core.impl.localsearch.decider.LocalSearchDecider
[1.066s][info][class,load] org.optaplanner.core.impl.localsearch.decider.forager.AcceptedLocalSearchForager$1 source: file:/Users/teejae/.m2/repository/org/optaplanner/optaplanner-core-impl/8.35.0-SNAPSHOT/optaplanner-core-impl-8.35.0-SNAPSHOT.jar
[1.411s][info][class,load] java.io.ObjectInput source: jrt:/java.base
[1.411s][info][class,load] org.drools.core.marshalling.MarshallerReaderContext source: file:/Users/teejae/.gradle/caches/modules-2/files-2.1/org.drools/drools-core/8.34.0.Final/78ac6d7b2d92ae42928be281e4ba0a652384c831/drools-core-8.34.0.Final.jar
[5.938s][info][class,load] io.micrometer.core.instrument.composite.CompositeLongTaskTimer$CompositeSample$$Lambda$637/0x000000080044a960 source: io.micrometer.core.instrument.composite.CompositeLongTaskTimer$CompositeSample
[5.939s][info][class,load] io.micrometer.core.instrument.composite.CompositeLongTaskTimer$CompositeSample$$Lambda$638/0x000000080044ab90 source: io.micrometer.core.instrument.composite.CompositeLongTaskTimer$CompositeSample
[5.939s][info][class,load] io.micrometer.core.instrument.composite.CompositeMeterRegistry$$Lambda$639/0x000000080044add8 source: io.micrometer.core.instrument.composite.CompositeMeterRegistry
[5.939s][info][class,load] io.micrometer.core.instrument.composite.CompositeMeterRegistry$$Lambda$640/0x000000080044b000 source: io.micrometer.core.instrument.composite.CompositeMeterRegistry
[5.939s][info][class,load] org.optaplanner.core.impl.solver.DefaultSolver$$Lambda$641/0x000000080044b238 source: org.optaplanner.core.impl.solver.DefaultSolver
[6.950s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$642/0x000000080044b470 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[6.951s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$643/0x000000080044b6b0 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[6.952s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$644/0x000000080044b8f0 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[6.952s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$645/0x000000080044bb30 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[7.060s][info][class,load] org.drools.ancompiler.Compiledorg_acme_schooltimetabling_domain_LessonNetwork31008790748 source: __JVM_DefineClass__
[7.061s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$646/0x000000080044bd70 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[7.062s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$647/0x000000080044e000 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[7.074s][info][class,load] jdk.internal.reflect.GeneratedConstructorAccessor2 source: __ClassDefiner__
[13.066s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$648/0x000000080044e240 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[13.066s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$649/0x000000080044e480 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[13.067s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$650/0x000000080044e6c0 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[13.067s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$651/0x000000080044e900 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[13.087s][info][class,load] jdk.internal.reflect.GeneratedConstructorAccessor3 source: __ClassDefiner__
[13.173s][info][class,load] org.drools.ancompiler.Compiledorg_acme_schooltimetabling_domain_LessonNetwork31008790748 source: __JVM_DefineClass__
[13.174s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$652/0x000000080044eb40 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
[13.174s][info][class,load] org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor$$Lambda$653/0x000000080044ed80 source: org.optaplanner.core.impl.domain.common.accessor.LambdaBeanPropertyMemberAccessor
```

<!--
Thank you for submitting this pull request.

*Do NOT use the default branch `stable` to create a pull request,
use the branch `development` instead. The latter uses SNAPSHOT versions.*

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.

Any changes to school-timetabling must be synced across its quarkus, kotlin-quarkus, and spring-boot variants, 
and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main/optaplanner-quickstart.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/kiegroup/drools/pull/3000
- https://github.com/kiegroup/optaplanner/pull/899
- etc.
-->

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
