### PR TITLE
Make the build reproducible

### DIFF
--- a/build/quickstarts-showcase/pom.xml
+++ b/build/quickstarts-showcase/pom.xml
@@ -16,6 +16,12 @@
     <java.module.name>org.optaplanner.quickstarts.showcase</java.module.name>
     <!-- Workaround for https://github.com/quarkusio/quarkus/issues/15817. -->
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
+    <version.source.plugin>3.3.0</version.source.plugin>
   </properties>
 
   <dependencyManagement>
@@ -127,6 +133,14 @@
             <phase>none</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/hello-world/pom.xml
+++ b/hello-world/pom.xml
@@ -20,6 +20,11 @@
     <version.compiler.plugin>3.10.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
     <version.assembly.plugin>3.4.2</version.assembly.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -129,6 +134,19 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/technology/java-activemq-quarkus/common/pom.xml
+++ b/technology/java-activemq-quarkus/common/pom.xml
@@ -31,7 +31,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -10,14 +10,21 @@
   <packaging>pom</packaging>
 
   <properties>
-    <version.org.apache.activemq>2.28.0</version.org.apache.activemq>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.org.apache.activemq>2.28.0</version.org.apache.activemq>
     <version.org.optaplanner>9.45.0-SNAPSHOT</version.org.optaplanner>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
-    <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.jandex.plugin>3.1.6</version.jandex.plugin>
+    <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <modules>
@@ -102,7 +109,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler-plugin.version}</version>
+          <version>${version.compiler.plugin}</version>
         </plugin>
         <plugin>
           <groupId>io.quarkus</groupId>
@@ -117,17 +124,30 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.jboss.jandex</groupId>
+          <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
-          <version>1.0.8</version>
+          <version>${version.jandex.plugin}</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire-plugin.version}</version>
+          <version>${version.surefire.plugin}</version>
           <configuration>
             <systemPropertyVariables>
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${version.jar.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-artifact-plugin</artifactId>
+          <version>${version.artifact.plugin}</version>
+          <configuration>
+            <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
           </configuration>
         </plugin>
       </plugins>
@@ -146,7 +166,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.surefire.plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/technology/java-spring-boot/pom.xml
+++ b/technology/java-spring-boot/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -142,6 +147,19 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -17,6 +17,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -213,6 +218,19 @@
             <option>all-open:annotation=jakarta.enterprise.context.ApplicationScoped</option>
             <option>all-open:annotation=io.quarkus.test.junit.QuarkusTest</option>
           </pluginOptions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/technology/kubernetes/common/pom.xml
+++ b/technology/kubernetes/common/pom.xml
@@ -47,7 +47,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -19,12 +19,18 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.org.apache.activemq>2.28.0</version.org.apache.activemq>
     <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.org.apache.activemq>2.28.0</version.org.apache.activemq>
     <version.org.optaplanner>9.45.0-SNAPSHOT</version.org.optaplanner>
+
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
-    <version.jandex.plugin>1.0.8</version.jandex.plugin>
+    <version.jandex.plugin>3.1.6</version.jandex.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -115,9 +121,22 @@
           <version>${version.surefire.plugin}</version>
         </plugin>
         <plugin>
-          <groupId>org.jboss.jandex</groupId>
+          <groupId>io.smallrye</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
           <version>${version.jandex.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${version.jar.plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-artifact-plugin</artifactId>
+          <version>${version.artifact.plugin}</version>
+          <configuration>
+            <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -138,6 +143,19 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -149,6 +154,19 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -126,6 +131,19 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -149,6 +154,19 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -135,6 +140,19 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -13,9 +13,14 @@
 
     <version.io.quarkus>3.0.0.Final</version.io.quarkus>
     <version.org.optaplanner>9.45.0-SNAPSHOT</version.org.optaplanner>
-    
+
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -157,6 +162,19 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -141,6 +146,19 @@
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -16,6 +16,11 @@
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>3.0.0-M8</version.surefire.plugin>
+
+    <!-- reproducible build -->
+    <project.build.outputTimestamp>2024-01-12T00:00:00Z</project.build.outputTimestamp>
+    <version.artifact.plugin>3.4.1</version.artifact.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
   </properties>
 
   <dependencyManagement>
@@ -147,6 +152,19 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${version.jar.plugin}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-artifact-plugin</artifactId>
+        <version>${version.artifact.plugin}</version>
+        <configuration>
+          <outputTimestamp>${project.build.outputTimestamp}</outputTimestamp>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Replicates changes from https://github.com/apache/incubator-kie-optaplanner/pull/3059. The only new thing is the jandex plugin update to a version that supports reproducible builds.

Unfortunately, the quickstart POMs _intentionally_ do not have a parent POM, so it's a lot of duplicated code. (Each quickstart is self-contained and easy to take out and modify. That's the reason for no parent POM.)

Contributes to https://github.com/apache/incubator-kie-issues/issues/846.