### PR TITLE
Upgrade to quarkus 3.8.0 in QuickStarts

### DIFF
--- a/technology/java-activemq-quarkus/pom.xml
+++ b/technology/java-activemq-quarkus/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.apache.activemq>2.28.0</version.org.apache.activemq>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 

--- a/technology/kotlin-quarkus/pom.xml
+++ b/technology/kotlin-quarkus/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.kotlin>1.8.20</version.kotlin>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 

--- a/technology/kubernetes/pom.xml
+++ b/technology/kubernetes/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.apache.activemq>2.28.0</version.org.apache.activemq>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 

--- a/use-cases/call-center/pom.xml
+++ b/use-cases/call-center/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/employee-scheduling/pom.xml
+++ b/use-cases/employee-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/facility-location/pom.xml
+++ b/use-cases/facility-location/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/maintenance-scheduling/pom.xml
+++ b/use-cases/maintenance-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/order-picking/pom.xml
+++ b/use-cases/order-picking/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/school-timetabling/build.gradle
+++ b/use-cases/school-timetabling/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
-    id "io.quarkus" version "3.0.0.Final"
+    id "io.quarkus" version "3.8.0"
 }
 
-def quarkusVersion = "3.0.0.Final"
+def quarkusVersion = "3.8.0"
 def optaplannerVersion = "999-SNAPSHOT"
 def assertjVersion = "3.24.2"
 

--- a/use-cases/school-timetabling/pom.xml
+++ b/use-cases/school-timetabling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vaccination-scheduling/pom.xml
+++ b/use-cases/vaccination-scheduling/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/use-cases/vehicle-routing/pom.xml
+++ b/use-cases/vehicle-routing/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.io.quarkus>3.0.0.Final</version.io.quarkus>
+    <version.io.quarkus>3.8.0</version.io.quarkus>
     <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION





### Referenced pull requests

Related to https://github.com/apache/incubator-kie-optaplanner/pull/3070

See https://github.com/apache/incubator-kie-issues/issues/958

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] tests</b>

- for a <b>full downstream build</b>  
  please add the label `run_fdb`

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner-quickstarts] mandrel-lts</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
