### PR TITLE
kie-issues#1237: stay on x.y.999-SNAPSHOT in release branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -43,8 +43,7 @@ pipeline {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
-                    optaplannerBranch = getBuildBranch() == 'development' ? '9.x' : getBuildBranch() == '8.x' ? 'main' : getBuildBranch()
-                    checkoutRepo(optaplannerRepo, optaplannerBranch)
+                    checkoutRepo(optaplannerRepo, getBuildBranch())
                     checkoutRepo(getRepoName(), getBuildBranch())
                 }
             }


### PR DESCRIPTION
Part of
* apache/incubator-kie-issues#1237

Adjusts the snapshot version changes to happen only in new branch when branching, not in main.

Ensemble:
* apache/incubator-kie-kogito-pipelines#1201
* apache/incubator-kie-drools#5967
* apache/incubator-kie-optaplanner#3089
* apache/incubator-kie-kogito-runtimes#3527
* apache/incubator-kie-kogito-apps#2059
* apache/incubator-kie-kogito-examples#1925
* apache/incubator-kie-optaplanner-quickstarts#630