### PR TITLE
Adjust development branch

### DIFF
--- a/.ci/environments/common/update_quarkus.sh
+++ b/.ci/environments/common/update_quarkus.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
 
-source <(curl -s https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/install_quarkus.sh)
+source <(curl -s https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/install_quarkus.sh)
 
 echo "Update project with Quarkus version ${QUARKUS_VERSION}"
 

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     options {
         timestamps()
         timeout(time: 720, unit: 'MINUTES')
+        disableConcurrentBuilds(abortPrevious: true)
     }
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-optaplanner-quickstarts'

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
     }
     environment {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-optaplanner-quickstarts'
-        BUILDCHAIN_CONFIG_REPO = 'apache/incubator-kie-optaplanner'
-        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
+        BUILDCHAIN_CONFIG_REPO = 'incubator-kie-optaplanner'
+        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config-pr-cdb.yaml'
 
         OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM = '-Dfull'
         BUILD_MVN_OPTS_CURRENT = '-Dfull'

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -1,0 +1,43 @@
+@Library('jenkins-pipeline-shared-libraries')_
+
+pr_check_script = null
+
+pipeline {
+    agent {
+        label 'ubuntu'
+    }
+    options {
+        timestamps()
+        timeout(time: 720, unit: 'MINUTES')
+    }
+    environment {
+        BUILDCHAIN_PROJECT = 'apache/incubator-kie-optaplanner-quickstarts'
+        BUILDCHAIN_CONFIG_REPO = 'apache/incubator-kie-optaplanner'
+        BUILDCHAIN_CONFIG_FILE_PATH = '.ci/buildchain-config.yaml'
+
+        OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM = '-Dfull'
+        BUILD_MVN_OPTS_CURRENT = '-Dfull'
+    }
+    stages {
+        stage('Initialize') {
+            steps {
+                script {
+                    // load `pr_check.groovy` file from kogito-pipelines:main
+                    dir('kogito-pipelines') {
+                        checkout(githubscm.resolveRepository('incubator-kie-kogito-pipelines', 'apache', 'main', false, 'kie-ci')) // TODO to change back to kiegroup:main
+                        pr_check_script = load 'dsl/scripts/pr_check.groovy'
+                    }
+                }
+            }
+        }
+        stage('PR check') {
+            steps {
+                script {
+                    dir('kogito-pipelines') {
+                        pr_check_script.launch()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 script {
                     // load `pr_check.groovy` file from kogito-pipelines:main
                     dir('kogito-pipelines') {
-                        checkout(githubscm.resolveRepository('incubator-kie-kogito-pipelines', 'apache', 'main', false, 'kie-ci')) // TODO to change back to kiegroup:main
+                        checkout(githubscm.resolveRepository('incubator-kie-kogito-pipelines', 'apache', 'main', false, 'kie-ci'))
                         pr_check_script = load 'dsl/scripts/pr_check.groovy'
                     }
                 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -91,7 +91,7 @@ pipeline {
                                 githubscm.findAndStageNotIgnoredFiles('pom.xml') 
                                 githubscm.findAndStageNotIgnoredFiles('build.gradle')
                             })
-                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
+                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorPushCredsId())
                         } else {
                             println '[WARN] no changes to commit'
                         }
@@ -124,7 +124,7 @@ void sendErrorNotification() {
 void checkoutRepo(String repository, String branch) {
     dir(repository) {
         deleteDir()
-        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
+        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false, getGitAuthorCredsId()))
         // need to manually checkout branch since on a detached branch after checkout command
         sh "git checkout ${branch}"
     }
@@ -147,8 +147,12 @@ String getOptaPlannerVersion() {
     return params.OPTAPLANNER_VERSION
 }
 
-String getGitAuthorCredsID() {
-    return env.AUTHOR_CREDS_ID
+String getGitAuthorCredsId() {
+    return env.GIT_AUTHOR_CREDS_ID
+}
+
+String getGitAuthorPushCredsId() {
+    return env.GIT_AUTHOR_PUSH_CREDS_ID
 }
 
 MavenCommand getMavenCommand(String directory) {

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -86,7 +86,7 @@ pipeline {
                     dir(getRepoName()) {
                         if (githubscm.isThereAnyChanges()) {
                             def commitMsg = "Update version to ${getOptaPlannerVersion()}"
-
+                            githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
                             githubscm.commitChanges(commitMsg, { 
                                 githubscm.findAndStageNotIgnoredFiles('pom.xml') 
                                 githubscm.findAndStageNotIgnoredFiles('build.gradle')

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -30,7 +30,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -45,17 +45,34 @@ pipeline {
         stage('Build OptaPlanner parents') {
             steps {
                 script {
-                    getMavenCommand(optaplannerRepo)
-                        .withOptions(['-U', '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom,org.optaplanner:optaplanner-operator', '-am'])
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(optaplannerRepo)
+                            .withOptions([
+                                '-U',
+                                '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom,org.optaplanner:optaplanner-operator',
+                                '-am'
+                            ])
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
         stage('Update project version') {
             steps {
                 script {
-                    maven.mvnSetVersionProperty(getMavenCommand(getRepoName()), 'version.org.optaplanner', getOptaPlannerVersion())
-                    maven.mvnVersionsUpdateParentAndChildModules(getMavenCommand(getRepoName()), getOptaPlannerVersion(), true)
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        maven.mvnSetVersionProperty(
+                            getMavenCommand(getRepoName()).withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            'version.org.optaplanner',
+                            getOptaPlannerVersion()
+                        )
+                        maven.mvnVersionsUpdateParentAndChildModules(
+                            getMavenCommand(getRepoName()).withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            getOptaPlannerVersion(),
+                            true
+                        )
+                    }
 
                     dir(getRepoName()) {
                         sh "find . -name build.gradle -exec sed -i -E 's/def optaplannerVersion = \"[^\"\\s]+\"/def optaplannerVersion = \"${getOptaPlannerVersion()}\"/' {} \\;"
@@ -89,7 +106,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -136,6 +153,5 @@ String getGitAuthorCredsID() {
 
 MavenCommand getMavenCommand(String directory) {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .inDirectory(directory)
 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -7,13 +7,10 @@ optaplannerRepo = 'incubator-kie-optaplanner'
 
 pipeline {
     agent {
-        label 'ubuntu'
-    }
-
-    tools {
         docker { 
             image env.AGENT_DOCKER_BUILDER_IMAGE
             args env.AGENT_DOCKER_BUILDER_ARGS
+            label util.avoidFaultyNodes('ubuntu')
         }
     }
 

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -33,7 +33,7 @@ pipeline {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
-                    optaplannerBranch = getBuildBranch() == 'development' ? '9.x' : getBuildBranch() == '8.x' ? 'main' : getBuildBranch()
+                    optaplannerBranch = getBuildBranch() == 'development' ? 'main' : getBuildBranch()
                     checkoutRepo(optaplannerRepo, optaplannerBranch)
                     checkoutRepo(getRepoName(), getBuildBranch())
                 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -3,16 +3,18 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 import org.kie.jenkins.MavenCommand
 
-optaplannerRepo = 'optaplanner'
+optaplannerRepo = 'incubator-kie-optaplanner'
 
 pipeline {
     agent {
-        label util.avoidFaultyNodes('kie-rhel8 && !built-in')
+        label 'ubuntu'
     }
 
     tools {
-        maven env.BUILD_MAVEN_TOOL
-        jdk env.BUILD_JDK_TOOL
+        docker { 
+            image env.AGENT_DOCKER_BUILDER_IMAGE
+            args env.AGENT_DOCKER_BUILDER_ARGS
+        }
     }
 
     options {
@@ -20,17 +22,8 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
     }
 
-    // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
-    // }
-
     environment {
-        // Static env is defined into ./dsl/jobs.groovy file
-
         OPTAPLANNER_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
-
-        // Keep here for visitibility
-        MAVEN_OPTS = '-Xms1024m -Xmx4g'
     }
 
     stages {
@@ -43,7 +36,8 @@ pipeline {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
-                    checkoutRepo(optaplannerRepo, getBuildBranch())
+                    optaplannerBranch = getBuildBranch() == 'development' ? '9.x' : getBuildBranch() == '8.x' ? 'main' : getBuildBranch()
+                    checkoutRepo(optaplannerRepo, optaplannerBranch)
                     checkoutRepo(getRepoName(), getBuildBranch())
                 }
             }
@@ -75,12 +69,12 @@ pipeline {
                     dir(getRepoName()) {
                         if (githubscm.isThereAnyChanges()) {
                             def commitMsg = "Update version to ${getOptaPlannerVersion()}"
-                            githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
+
                             githubscm.commitChanges(commitMsg, { 
                                 githubscm.findAndStageNotIgnoredFiles('pom.xml') 
                                 githubscm.findAndStageNotIgnoredFiles('build.gradle')
                             })
-                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorPushCredsId())
+                            githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
                         } else {
                             println '[WARN] no changes to commit'
                         }
@@ -113,7 +107,7 @@ void sendErrorNotification() {
 void checkoutRepo(String repository, String branch) {
     dir(repository) {
         deleteDir()
-        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false, getGitAuthorCredsId()))
+        checkout(githubscm.resolveRepository(repository, getGitAuthor(), branch, false))
         // need to manually checkout branch since on a detached branch after checkout command
         sh "git checkout ${branch}"
     }
@@ -136,12 +130,8 @@ String getOptaPlannerVersion() {
     return params.OPTAPLANNER_VERSION
 }
 
-String getGitAuthorCredsId() {
-    return env.GIT_AUTHOR_CREDS_ID
-}
-
-String getGitAuthorPushCredsId() {
-    return env.GIT_AUTHOR_PUSH_CREDS_ID
+String getGitAuthorCredsID() {
+    return env.AUTHOR_CREDS_ID
 }
 
 MavenCommand getMavenCommand(String directory) {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/kiegroup/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/incubator-kie-kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/incubator-kie-kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType
@@ -35,7 +35,7 @@ Map getMultijobPRConfig() {
 }
 
 // Optaplanner PR checks
-KogitoJobUtils.createAllEnvironmentsPerRepoPRJobs(this) { jobFolder -> getMultijobPRConfig() }
+Utils.isMainBranch(this) && KogitoJobTemplate.createPullRequestMultibranchPipelineJob(this, "${jenkins_path}/Jenkinsfile")
 
 // Init branch
 createSetupBranchJob()
@@ -62,9 +62,8 @@ void setupSpecificBuildChainNightlyJob(String envName) {
 
 void createSetupBranchJob() {
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'optaplanner-quickstarts', JobType.SETUP_BRANCH, "${jenkins_path}/Jenkinsfile.setup-branch", 'OptaPlanner Quickstarts Setup Branch')
-    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([
-        REPO_NAME: 'optaplanner-quickstarts',
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -22,13 +22,13 @@ fi
 
 git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
 
-export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/optaplanner
-export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=kiegroup/optaplanner
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/incubator-kie-optaplanner
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=apache/incubator-kie-optaplanner
 export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
-export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/optaplanner
+export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/incubator-kie-optaplanner
 
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,11 +19,11 @@ and also the external https://github.com/quarkusio/quarkus-quickstarts/tree/main
 ### Referenced pull requests
 
 <!-- Add URLs of all referenced pull requests if they exist. This is only required when making
-changes that span multiple kiegroup repositories and depend on each other. -->
+changes that span multiple KIE repositories and depend on each other. -->
 <!-- Example:
 - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
-- https://github.com/kiegroup/drools/pull/3000
-- https://github.com/kiegroup/optaplanner/pull/899
+- https://github.com/apache/incubator-kie-drools/pull/3000
+- https://github.com/apache/incubator-kie-optaplanner/pull/899
 - etc.
 -->
 

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -52,12 +52,16 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/github-action-build-chain@v3.1.10
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/incubator-kie-optaplanner/main/.ci/buildchain-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: "-Dfull"
-      - name: Surefire Report
-        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/surefire-report@main
+      - name: Check Surefire Report
         if: ${{ always() }}
+        uses: ScaCap/action-surefire-report@v1.6.2
+        with:
+          fail_on_test_failures: true
+          fail_if_no_tests: false
+          skip_publishing: true

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -54,7 +54,7 @@ jobs:
         id: build-chain
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/incubator-kie-optaplanner/main/.ci/buildchain-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP:apache}/incubator-kie-optaplanner/${BRANCH:main}/.ci/buildchain-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: "-Dfull"

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -52,16 +52,12 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/github-action-build-chain@v3.1.10
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/build-chain@main
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/incubator-kie-optaplanner/main/.ci/buildchain-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           OPTAPLANNER_BUILD_MVN_OPTS_UPSTREAM: "-Dfull"
-      - name: Check Surefire Report
+      - name: Surefire Report
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/surefire-report@main
         if: ${{ always() }}
-        uses: ScaCap/action-surefire-report@v1.6.2
-        with:
-          fail_on_test_failures: true
-          fail_if_no_tests: false
-          skip_publishing: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Support long paths
         if: ${{ matrix.os == 'windows-latest' }}
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/long-paths@main
-      - name: Sets the migration env variable on Windows
-        if: runner.os == 'Windows'
-        run: echo "MIGRATE_TO_9=${{ github.base_ref == 'development' }}" >> $env:GITHUB_ENV
-      - name: Sets the migration env variable on Linux
-        if: runner.os != 'Windows'
-        run: echo "MIGRATE_TO_9=${{ github.base_ref == 'development' }}" >> $GITHUB_ENV
       - name: Java and Maven Setup
         uses: apache/incubator-kie-kogito-pipelines/.ci/actions/maven@main
         with:

--- a/README.adoc
+++ b/README.adoc
@@ -33,8 +33,8 @@ Run the https://www.optaplanner.org/[OptaPlanner] quickstarts now:
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
-$ cd optaplanner-quickstarts
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
+$ cd incubator-kie-optaplanner-quickstarts
 $ ./runQuickstartsFromSource.sh
 ----
 

--- a/build/optaplanner-distribution/src/main/assembly/resources/ReadMe.txt
+++ b/build/optaplanner-distribution/src/main/assembly/resources/ReadMe.txt
@@ -12,7 +12,7 @@ On Windows:
 Run the quickstarts in IDE
 ----------------------------
 
-Please refer to https://github.com/kiegroup/optaplanner-quickstarts/blob/stable/README.adoc.
+Please refer to https://github.com/apache/incubator-kie-optaplanner-quickstarts/blob/stable/README.adoc.
 
 Run the examples
 ----------------
@@ -56,7 +56,7 @@ Sources
 -------
 
 But to build from sources, pull the sources with git:
-  https://github.com/kiegroup/optaplanner
+  https://github.com/apache/incubator-kie-optaplanner
 
 Backwards compatibility
 -----------------------

--- a/build/quickstarts-showcase/src/main/resources/META-INF/resources/index.html
+++ b/build/quickstarts-showcase/src/main/resources/META-INF/resources/index.html
@@ -14,7 +14,7 @@
         </a>
         <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-                <a class="nav-link" href="https://github.com/kiegroup/optaplanner-quickstarts" target="_blank">Source code</a>
+                <a class="nav-link" href="https://github.com/apache/incubator-kie-optaplanner-quickstarts" target="_blank">Source code</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://www.optaplanner.org/learn/documentation.html" target="_blank">Documentation</a>

--- a/hello-world/README.adoc
+++ b/hello-world/README.adoc
@@ -8,9 +8,9 @@ Assign lessons to timeslots and rooms to produce a better schedule for teachers 
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/hello-world
+$ cd incubator-kie-optaplanner-quickstarts/hello-world
 ----
 
 . Start the application with Maven:

--- a/technology/java-activemq-quarkus/README.adoc
+++ b/technology/java-activemq-quarkus/README.adoc
@@ -11,9 +11,9 @@ The quickstart consists of two modules:
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/technology/java-activemq-quarkus
+$ cd incubator-kie-optaplanner-quickstarts/technology/java-activemq-quarkus
 ----
 
 . Build the project:

--- a/technology/java-spring-boot/README.adoc
+++ b/technology/java-spring-boot/README.adoc
@@ -13,9 +13,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/technology/java-spring-boot
+$ cd incubator-kie-optaplanner-quickstarts/technology/java-spring-boot
 ----
 
 . Start the application with Maven:

--- a/technology/kotlin-quarkus/README.adoc
+++ b/technology/kotlin-quarkus/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/technology/kotlin-quarkus
+$ cd incubator-kie-optaplanner-quickstarts/technology/kotlin-quarkus
 ----
 
 . Start the application with Maven:
@@ -92,7 +92,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/technology/kotlin-quarkus`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/technology/kubernetes/README.adoc
+++ b/technology/kubernetes/README.adoc
@@ -73,7 +73,7 @@ Follow the https://keda.sh/docs/deploy/[documentation] to install the KEDA opera
 
 ==== Deploy the OptaPlanner Operator
 
-Follow the https://github.com/kiegroup/optaplanner/tree/main/optaplanner-operator#deploy-the-optaplanner-operator[README] to install the OptaPlanner operator.
+Follow the https://github.com/apache/incubator-kie-optaplanner/tree/main/optaplanner-operator#deploy-the-optaplanner-operator[README] to install the OptaPlanner operator.
 
 ==== Deploy the Demo App
 

--- a/use-cases/call-center/README.adoc
+++ b/use-cases/call-center/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/call-center
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/call-center
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/call-center`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/employee-scheduling/README.adoc
+++ b/use-cases/employee-scheduling/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/employee-scheduling
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/employee-scheduling
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/employee-scheduling`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/facility-location/README.adoc
+++ b/use-cases/facility-location/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/facility-location
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/facility-location
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/facility-location`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/maintenance-scheduling/README.adoc
+++ b/use-cases/maintenance-scheduling/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/maintenance-scheduling
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/maintenance-scheduling
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/maintenance-scheduling`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/order-picking/README.adoc
+++ b/use-cases/order-picking/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/order-picking
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/order-picking
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/order-picking`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/school-timetabling/README.adoc
+++ b/use-cases/school-timetabling/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/school-timetabling
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/school-timetabling
 ----
 
 . Start the application with Maven:
@@ -108,7 +108,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/school-timetabling`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/vaccination-scheduling/README.adoc
+++ b/use-cases/vaccination-scheduling/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/vaccination-scheduling
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/vaccination-scheduling
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/vaccination-scheduling`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:

--- a/use-cases/vehicle-routing/README.adoc
+++ b/use-cases/vehicle-routing/README.adoc
@@ -16,9 +16,9 @@ image::../../build/quickstarts-showcase/src/main/resources/META-INF/resources/sc
 +
 [source, shell]
 ----
-$ git clone https://github.com/kiegroup/optaplanner-quickstarts.git
+$ git clone https://github.com/apache/incubator-kie-optaplanner-quickstarts.git
 ...
-$ cd optaplanner-quickstarts/use-cases/vehicle-routing
+$ cd incubator-kie-optaplanner-quickstarts/use-cases/vehicle-routing
 ----
 
 . Start the application with Maven:
@@ -87,7 +87,7 @@ To deploy the application on OpenShift:
 . In the OpenShift web console, verify that the top left combobox is set to _Developer_ (not _Administrator_).
 . In the menu, select *Add* to create an application.
 . Under *Git Repository*, click *Import from Git* and fill in these parameters:
-.. Set *Git Repo URL* to `https://github.com/kiegroup/optaplanner-quickstarts`
+.. Set *Git Repo URL* to `https://github.com/apache/incubator-kie-optaplanner-quickstarts`
 .. Under _Show advanced Git options_, set *Context dir* to `/use-cases/vehicle-routing`
 .. Press the *Create* button.
 . In the _Topology_ view, there is a new deployment:


### PR DESCRIPTION
development branch is lacking many changes that were made only to 8.x because that was the "branch-to-get" right after apache transfer. After quarkus upgrade, development branch has effectively become the branch to use, but no one adjusted CI and the branch itself to map to what is actually needed (and was done in 8.x).

I am backporting in batch commits from 8.x (some adjusted to fit development branch config differences - jdks, etc).