### PR TITLE
[10.0.x] CI duplicate maven configuration entries

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -70,7 +70,7 @@ void createSetupBranchJob() {
         GIT_AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
         GIT_AUTHOR_PUSH_CREDS_ID: "${GIT_AUTHOR_PUSH_CREDENTIALS_ID}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.NIGHTLY.name),
 
         IS_MAIN_BRANCH: "${Utils.isMainBranch(this)}"
     ])


### PR DESCRIPTION
Adjusting branch.yaml configuration to split maven related configurations for nightly and release.

Part of ensemble:

- apache/incubator-kie-kogito-pipelines#1254
- apache/incubator-kie-drools#6130
- apache/incubator-kie-optaplanner#3133
- apache/incubator-kie-optaplanner-quickstarts#634
- apache/incubator-kie-kogito-runtimes#3737
- apache/incubator-kie-kogito-apps#2119
- apache/incubator-kie-kogito-examples#2025

The scope of changes:

- maven settings.xml reference (config file id pointing at pre-defined config file in jenkins)
- artifacts upload repository
  - url - mostly informational, should not be needed for deploy itself (inheriting that configuration from apache parent)
  - credentials-id - the important part, allowing to configure different credentials for nightly and release.

Notes:
- in some places the configuration variants denoted as nightly are used in other places too (e.g. setup-branch).

Follow-up:

- after this gets merged, incubator-kie-kogito-pipelines PR needs to be backported also into branches:
  - seed-drools-10.0.x
  - seed-kogito-10.0.x
  - seed-optaplanner-10.0.x 