### PR TITLE
[issue-639] Disable scheduled nigthly as not used

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,8 +2,8 @@
 name: Nightly
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
+#  schedule:
+#    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removing scheduled nightly and kept only manual triggering for a case until all problems with used actions are sorted out in https://github.com/apache/incubator-kie-optaplanner-quickstarts/issues/639